### PR TITLE
feat: TextDividerList 컴포넌트 개발

### DIFF
--- a/src/components/atoms/Divider/styled.ts
+++ b/src/components/atoms/Divider/styled.ts
@@ -1,3 +1,5 @@
 import styled from "@emotion/styled";
 
-export const DividerWrapper: ReturnType<typeof styled.hr> = styled.hr``;
+export const DividerWrapper: ReturnType<typeof styled.hr> = styled.hr`
+  margin: 0;
+`;

--- a/src/components/atoms/Divider/styled.ts
+++ b/src/components/atoms/Divider/styled.ts
@@ -1,5 +1,3 @@
 import styled from "@emotion/styled";
 
-export const DividerWrapper: ReturnType<typeof styled.hr> = styled.hr`
-  margin: 0;
-`;
+export const DividerWrapper: ReturnType<typeof styled.hr> = styled.hr``;

--- a/src/components/atoms/Text/index.tsx
+++ b/src/components/atoms/Text/index.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, FC } from "react";
+import type { HTMLAttributes } from "react";
 import { H1Wrapper, H5Wrapper, Body1Wrapper, ButtonWrapper } from "./styled";
 
 interface ITextProps extends HTMLAttributes<HTMLParagraphElement> {
@@ -16,10 +16,14 @@ const variantMap: {
   h1: H1Wrapper,
   h5: H5Wrapper,
   body1: Body1Wrapper,
-  button: ButtonWrapper
+  button: ButtonWrapper,
 };
 
-export const Text = ({ content, variant = "body1" }: ITextProps) => {
+export const Text = ({
+  content,
+  variant = "body1",
+  onClick = () => {},
+}: ITextProps) => {
   const Component = variantMap[variant];
-  return <Component>{content}</Component>;
+  return <Component onClick={onClick}>{content}</Component>;
 };

--- a/src/components/molecules/TextDividerList/index.tsx
+++ b/src/components/molecules/TextDividerList/index.tsx
@@ -1,0 +1,25 @@
+import { Fragment } from "react";
+import { Divider, Text } from "components/atoms";
+import { TextDividerTextWrapper, TextDividerListWrapper } from "./styled";
+
+interface ITextDividerListProps {
+  /** 리스트에 표시 될 아이템 목록 */
+  items: string[];
+  /** 아이템 클릭 시 실행 될 이벤트 */
+  onClick: (item: string) => void;
+}
+
+export const TextDividerList = ({ items, onClick }: ITextDividerListProps) => {
+  return (
+    <TextDividerListWrapper>
+      {items.map((item, idx) => (
+        <Fragment key={`${idx}_${item}`}>
+          <TextDividerTextWrapper>
+            <Text content={item} onClick={() => onClick(item)} />
+          </TextDividerTextWrapper>
+          <Divider />
+        </Fragment>
+      ))}
+    </TextDividerListWrapper>
+  );
+};

--- a/src/components/molecules/TextDividerList/stories.ts
+++ b/src/components/molecules/TextDividerList/stories.ts
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { TextDividerList } from ".";
+
+const meta: Meta<typeof TextDividerList> = {
+  title: "Molecules/TextDividerList",
+  component: TextDividerList,
+  tags: ["autodocs"],
+};
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    items: [
+      "서울 관악구 신림동",
+      "서울 관악구 봉천동",
+      "서울 관악구 남현동",
+      "서울 동작구 노량진1-2동",
+      "서울 동작구 상도1-4동",
+      "서울 동작구 흑석동",
+      "서울 동작구 사당1-5동",
+      "서울 동작구 대방동",
+      "서울 동작구 신대방1-2동",
+    ],
+    onClick: (item) => console.log(item),
+  },
+};
+
+export default meta;

--- a/src/components/molecules/TextDividerList/styled.ts
+++ b/src/components/molecules/TextDividerList/styled.ts
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+
+export const TextDividerTextWrapper: ReturnType<typeof styled.div> = styled.div`
+  padding: 0.5rem;
+  &:hover {
+    background-color: #eeeeee;
+  }
+`;
+
+export const TextDividerListWrapper: ReturnType<typeof styled.div> = styled.div`
+  cursor: pointer;
+`;

--- a/src/index.css
+++ b/src/index.css
@@ -132,3 +132,7 @@ table {
 * {
   box-sizing: border-box;
 }
+
+hr {
+  margin: 0;
+}


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #23 
- #3 #10 

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->

TextDividerList 컴포넌트를 개발했습니다.

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->

- Text 컴포넌트를 수정했습니다.
    - lint에 걸리는 FC 제거
    - onClick 추가
- Divider 컴포넌트(styled)을 수정했습니다.
    - 기본적으로 hr에 적용되어있던 margin 제거
- Text를 바로 사용하지 않고 TextDividerTextWrapper로 묶어서 사용했습니다.
    - padding: 0.5rem, hover 시 배경 색상 변경 만 적용되어있습니다.
- 아이템 선택 시 이벤트를 화면쪽에서 생각해보면 items의 타입이 객체 형태가 되는 것이 좋아보이는데(해당하는 동네의 지역코드를 사용해 처리 등등....) 이 부분은 별도로 적용하진 않았습니다. 필요하다면 이후 작업에서 설정이 필요합니다.

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

![image](https://github.com/user-attachments/assets/d6ad9a5f-9464-4f94-8320-ead527a6dee4)
