### PR TITLE
feat: day.js 설치 및 남은 시간 formatting 하는 함수 개발

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "^11.13.0",
     "@tanstack/react-query": "^5.60.6",
     "@tanstack/react-query-devtools": "^5.60.6",
+    "dayjs": "^1.11.13",
     "framer-motion": "^11.11.17",
     "lodash-es": "^4.17.21",
     "react": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,18 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { getRelativeTime, getTimeRemaining } from "utils/dayFormatter";
 
 const queryClient: QueryClient = new QueryClient();
 
 const App = () => {
+  console.log(getRelativeTime("2024-11-25T14:36:00"));
+  // 출력 예시 (현재 시간 기준): "1일 전"
+
+  console.log(getRelativeTime("2023-11-25T14:36:00"));
+  // 출력 예시: "1년 전"
+
+  console.log(getRelativeTime("2024-11-25T14:35:50"));
+  // 출력 예시: "10초 전"
   return (
     <QueryClientProvider client={queryClient}>
       <>App</>

--- a/src/utils/dayFormatter.ts
+++ b/src/utils/dayFormatter.ts
@@ -1,0 +1,71 @@
+import dayjs from "dayjs";
+
+/**
+ * 현재 시간이랑 param으로 들어온 Date 비교해서 남은 시간을 `XX일 XX시간 XX분 XX초` 형태로 리턴하는 함수입니다.
+ * @param targetDate Date
+ * @returns string
+ */
+export const getTimeRemaining = (targetDate: Date): string => {
+  const now = dayjs();
+  const target = dayjs(targetDate);
+
+  if (target.isBefore(now)) {
+    return "마감시간이 지나 경매가 종료되었습니다!";
+  }
+
+  const diff = target.diff(now);
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
+  const minutes = Math.floor((diff / (1000 * 60)) % 60);
+  const seconds = Math.floor((diff / 1000) % 60);
+
+  const parts: string[] = [];
+
+  if (days > 0) parts.push(`${days}일`);
+  if (hours > 0) parts.push(`${hours}시간`);
+  if (minutes > 0) parts.push(`${String(minutes).padStart(2, "0")}분`);
+  if (seconds > 0) parts.push(`${String(seconds).padStart(2, "0")}초`);
+
+  return parts.join(" ");
+};
+
+/**
+ * 현재 시간이랑 param으로 들어온 Date 비교해서 남은 시간을 아래 형태로 변경하는 함수
+ * 1초 ~ 59초 = "n 초 전",
+ * 1분 ~ 59분 = "n 분 전",
+ * 1시 ~ 23시간 = "n 시간 전"
+ * 1일 ~ 29일 = "n 일 전"
+ * 30일 ~ 364일 = "n 개월 전"
+ * 365일 단위로 = "n 년 전"
+ * @param date Date
+ * @returns string
+ */
+export const getRelativeTime = (date: string): string => {
+  const now = dayjs();
+  const target = dayjs(date);
+
+  if (target.isAfter(now)) {
+    return "전달받은 시간 값이 미래의 시간입니다.";
+  }
+
+  const diffInSeconds = now.diff(target, "second");
+  const diffInMinutes = now.diff(target, "minute");
+  const diffInHours = now.diff(target, "hour");
+  const diffInDays = now.diff(target, "day");
+  const diffInMonths = now.diff(target, "month");
+  const diffInYears = now.diff(target, "year");
+
+  if (diffInSeconds < 60) {
+    return `${diffInSeconds}초 전`;
+  } else if (diffInMinutes < 60) {
+    return `${diffInMinutes}분 전`;
+  } else if (diffInHours < 24) {
+    return `${diffInHours}시간 전`;
+  } else if (diffInDays < 30) {
+    return `${diffInDays}일 전`;
+  } else if (diffInDays < 365) {
+    return `${diffInMonths}개월 전`;
+  } else {
+    return `${diffInYears}년 전`;
+  }
+};

--- a/src/utils/dayFormatter.ts
+++ b/src/utils/dayFormatter.ts
@@ -1,4 +1,14 @@
 import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import relativeTime from "dayjs/plugin/relativeTime";
+import "dayjs/locale/ko"; /** 한국어 로케일 임포트 */
+
+/** 플러그인 확장 */
+dayjs.extend(duration);
+dayjs.extend(relativeTime);
+
+/** 로케일 설정 (한국어) */
+dayjs.locale("ko");
 
 /**
  * 현재 시간이랑 param으로 들어온 Date 비교해서 남은 시간을 `XX일 XX시간 XX분 XX초` 형태로 리턴하는 함수입니다.
@@ -13,24 +23,22 @@ export const getTimeRemaining = (targetDate: Date): string => {
     return "마감시간이 지나 경매가 종료되었습니다!";
   }
 
-  const diff = target.diff(now);
-  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-  const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
-  const minutes = Math.floor((diff / (1000 * 60)) % 60);
-  const seconds = Math.floor((diff / 1000) % 60);
-
+  const diff = dayjs.duration(target.diff(now));
   const parts: string[] = [];
 
-  if (days > 0) parts.push(`${days}일`);
-  if (hours > 0) parts.push(`${hours}시간`);
-  if (minutes > 0) parts.push(`${String(minutes).padStart(2, "0")}분`);
-  if (seconds > 0) parts.push(`${String(seconds).padStart(2, "0")}초`);
+  if (diff.days() > 0) parts.push(`${diff.days()}일`);
+  if (diff.hours() > 0) parts.push(`${diff.hours()}시간`);
+  if (diff.minutes() > 0)
+    parts.push(`${String(diff.minutes()).padStart(2, "0")}분`);
+  if (diff.seconds() > 0)
+    parts.push(`${String(diff.seconds()).padStart(2, "0")}초`);
 
   return parts.join(" ");
 };
 
 /**
  * 현재 시간이랑 param으로 들어온 Date 비교해서 남은 시간을 아래 형태로 변경하는 함수
+ * https://day.js.org/docs/en/durations/humanize 참조 바람
  * 1초 ~ 59초 = "n 초 전",
  * 1분 ~ 59분 = "n 분 전",
  * 1시 ~ 23시간 = "n 시간 전"
@@ -40,32 +48,11 @@ export const getTimeRemaining = (targetDate: Date): string => {
  * @param date Date
  * @returns string
  */
-export const getRelativeTime = (date: string): string => {
+export const getRelativeTime = (date: Date): string => {
   const now = dayjs();
   const target = dayjs(date);
-
   if (target.isAfter(now)) {
     return "전달받은 시간 값이 미래의 시간입니다.";
   }
-
-  const diffInSeconds = now.diff(target, "second");
-  const diffInMinutes = now.diff(target, "minute");
-  const diffInHours = now.diff(target, "hour");
-  const diffInDays = now.diff(target, "day");
-  const diffInMonths = now.diff(target, "month");
-  const diffInYears = now.diff(target, "year");
-
-  if (diffInSeconds < 60) {
-    return `${diffInSeconds}초 전`;
-  } else if (diffInMinutes < 60) {
-    return `${diffInMinutes}분 전`;
-  } else if (diffInHours < 24) {
-    return `${diffInHours}시간 전`;
-  } else if (diffInDays < 30) {
-    return `${diffInDays}일 전`;
-  } else if (diffInDays < 365) {
-    return `${diffInMonths}개월 전`;
-  } else {
-    return `${diffInYears}년 전`;
-  }
+  return dayjs.duration(target.diff(now)).humanize(true);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2017,6 +2017,11 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+dayjs@^1.11.13:
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
+  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
+
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #68 

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->
- 물품 상세 페이지 내 경매 마감 시간(남은 시간)으로 바꿔주는 유틸 함수 작성
기존 이슈에서는 00:00:00 으로 나타내기로 되어있었는데, 개발하면서 생각을 해보니 3일이 넘어가는 마감시간의 경우는 사용자 입장에서 날짜를 역산하기 쉽지 않을 거 같아 `XX일 XX시간 XX분 XX초` 형태로 변경하였습니다.  

- n시간 전 유틸 함수 구현(채팅 온 시간이나 글 작성 시간 나타내는 유틸 함수)
해당 부분은 이슈와 동일하게 구현하였습니다.

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->
- utils 폴더 생성하여 dayFormatter.ts에 작성하였습니다.

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/6f0f7d5c-ac09-4007-bccf-7a82b845383b)

