### PR TITLE
feat: CategoryGrid 컴포넌트 개발

### DIFF
--- a/src/components/molecules/IconWithText_legacy/index.tsx
+++ b/src/components/molecules/IconWithText_legacy/index.tsx
@@ -13,12 +13,12 @@ export interface IIconWithTextProps {
   /** 아이콘 위치 ,default는 왼쪽 */
   iconLocation?: "default" | "right";
 }
-const IconWithText = ({
+export const IconWithText_Legacy = ({
   icon,
   content,
   desc,
   onClick,
-  iconLocation = "default"
+  iconLocation = "default",
 }: IIconWithTextProps) => {
   const IconComponent = icon;
   return (

--- a/src/components/molecules/IconWithText_legacy/stories.ts
+++ b/src/components/molecules/IconWithText_legacy/stories.ts
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { IconWithText } from ".";
+import { IconWithText_Legacy } from ".";
 import { LocationIcon } from "components/atoms/Icon";
 
-const meta: Meta<typeof IconWithText> = {
-  title: "Molecules/IconWithText",
-  component: IconWithText,
+const meta: Meta<typeof IconWithText_Legacy> = {
+  title: "Molecules/IconWithText_Legacy",
+  component: IconWithText_Legacy,
   tags: ["autodocs"],
 };
 export default meta;

--- a/src/components/organisms/CategoryGrid/index.tsx
+++ b/src/components/organisms/CategoryGrid/index.tsx
@@ -1,0 +1,37 @@
+import { RoundImageWithText } from "components/molecules";
+import { CategoryGridWrapper } from "./styled";
+
+export interface ICategory {
+  title: string;
+  imgUrl: string;
+}
+export interface ICategoryGridWrapperProps {
+  categories: ICategory[];
+  onClick: () => void;
+}
+
+export const CategoryGrid = ({
+  categories,
+  onClick,
+}: ICategoryGridWrapperProps) => {
+  const handleClick = (name: string) => {
+    console.log(name);
+    onClick();
+  };
+  return (
+    <CategoryGridWrapper>
+      {categories.map((category, idx) => {
+        return (
+          <RoundImageWithText
+            key={idx}
+            imgUrl={category.imgUrl}
+            title={category.title}
+            onClick={() => {
+              handleClick(category.title);
+            }}
+          ></RoundImageWithText>
+        );
+      })}
+    </CategoryGridWrapper>
+  );
+};

--- a/src/components/organisms/CategoryGrid/index.tsx
+++ b/src/components/organisms/CategoryGrid/index.tsx
@@ -1,5 +1,5 @@
 import { RoundImageWithText } from "components/molecules";
-import { CategoryGridWrapper } from "./styled";
+import { CategoryGridWrapper, CategoryItemWrapper } from "./styled";
 
 export interface ICategory {
   title: string;
@@ -22,14 +22,15 @@ export const CategoryGrid = ({
     <CategoryGridWrapper>
       {categories.map((category, idx) => {
         return (
-          <RoundImageWithText
-            key={idx}
-            imgUrl={category.imgUrl}
-            title={category.title}
-            onClick={() => {
-              handleClick(category.title);
-            }}
-          ></RoundImageWithText>
+          <CategoryItemWrapper key={idx}>
+            <RoundImageWithText
+              imgUrl={category.imgUrl}
+              title={category.title}
+              onClick={() => {
+                handleClick(category.title);
+              }}
+            ></RoundImageWithText>
+          </CategoryItemWrapper>
         );
       })}
     </CategoryGridWrapper>

--- a/src/components/organisms/CategoryGrid/stories.ts
+++ b/src/components/organisms/CategoryGrid/stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CategoryGrid, ICategory } from ".";
+
+const meta: Meta<typeof CategoryGrid> = {
+  title: "Organisms/CategoryGrid",
+  component: CategoryGrid,
+  tags: ["autodocs"],
+};
+
+type Story = StoryObj<typeof meta>;
+
+const categories: ICategory[] = Array.from({ length: 17 }, (_, idx) => ({
+  title: `Category ${idx + 1}`, // title을 Category 1, Category 2, ...로 설정
+  imgUrl: `/Default_Img.png`, // imgUrl을 Default_Img_1.png, Default_Img_2.png, ...로 설정
+}));
+export const Default: Story = {
+  args: {
+    categories: categories,
+    onClick: () => console.log("카테고리 클릭"),
+  },
+};
+
+export default meta;

--- a/src/components/organisms/CategoryGrid/styled.ts
+++ b/src/components/organisms/CategoryGrid/styled.ts
@@ -3,9 +3,14 @@ import styled from "@emotion/styled";
 export const CategoryGridWrapper: ReturnType<typeof styled.div> = styled.div`
   width: 375px;
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  /** 둘의 차이가 무엇인지...
-   * grid-template-columns: repeat(4, 1fr);
-  */
+
+  grid-template-columns: repeat(4, 1fr);
   gap: 8px;
+`;
+
+export const CategoryItemWrapper: ReturnType<typeof styled.div> = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  text-align: center;
 `;

--- a/src/components/organisms/CategoryGrid/styled.ts
+++ b/src/components/organisms/CategoryGrid/styled.ts
@@ -1,0 +1,11 @@
+import styled from "@emotion/styled";
+
+export const CategoryGridWrapper: ReturnType<typeof styled.div> = styled.div`
+  width: 375px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  /** 둘의 차이가 무엇인지...
+   * grid-template-columns: repeat(4, 1fr);
+  */
+  gap: 8px;
+`;


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #66 

## 💭 작업 내용
- CategoryGrid  컴포넌트 개발 완료

- IconwithText 관련해서 legacy로 파일명이 바뀌면서 기존 Storybook에서 해당 경로를 못 찾는 문제가 생겼습니다.
이 부분도 같이 해결해놨습니다.
 
- 올려드린 처음 사진을 보시면 category 9번의 높이가 늘어지는 현상이 발견되었습니다. 
category 9 보다 category 10 이 1글자 더 많아서 줄바뀜으로 생기는 현상인데, 이걸 위해 별도의 Category Item마다 별도의 Wrapper 씌워주는 방식으로 해결 했습니다. 
<!-- 작업한 내용을 간단히 설명해주세요 -->

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->

CategoryItemWrapper 를 추가한 경우 둘의 결과는 또 동일하게 나오네요.. 일단 마치기전에 말씀드린 부분은 잊어주시죠!
   * grid-template-columns: repeat(4, minmax(0, 1fr));
   * grid-template-columns: repeat(4, 1fr);
   
## 📸 스크린샷

![image](https://github.com/user-attachments/assets/a13b4ec6-55b2-4bdb-b61d-e0180122ffa9)
![image](https://github.com/user-attachments/assets/9851bd10-7588-4a5c-adce-a203645f527d)
