### PR TITLE
feat: MyPageMenu 컴포넌트 개발

### DIFF
--- a/src/components/organisms/MyPageMenu/index.tsx
+++ b/src/components/organisms/MyPageMenu/index.tsx
@@ -1,0 +1,32 @@
+import { Text } from "components/atoms";
+import { IconWithText } from "components/molecules";
+import { MY_PAGE_MENUS } from "constants/myPageMenus";
+import { MainMenuWrapper, MyPageMenuWrapper, SubMenuWrapper } from "./styled";
+
+interface IMyPageMenuProps {
+  /** 메뉴 클릭 시 실행 될 함수 */
+  onMenuClick: (pathname: string) => void;
+}
+
+export const MyPageMenu = ({ onMenuClick }: IMyPageMenuProps) => {
+  return (
+    <MyPageMenuWrapper>
+      {MY_PAGE_MENUS.map(({ title, menus }, idx) => (
+        <MainMenuWrapper key={`m_root_${idx}`}>
+          <Text content={title} variant="h5" />
+          <SubMenuWrapper>
+            {menus.map(({ icon, name, pathname }, i) => (
+              <IconWithText
+                key={`m_${idx}_${i}`}
+                onClick={() => onMenuClick(pathname)}
+              >
+                <IconWithText.Icon icon={icon} size="s" />
+                <IconWithText.Content content={name} />
+              </IconWithText>
+            ))}
+          </SubMenuWrapper>
+        </MainMenuWrapper>
+      ))}
+    </MyPageMenuWrapper>
+  );
+};

--- a/src/components/organisms/MyPageMenu/stories.ts
+++ b/src/components/organisms/MyPageMenu/stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { MyPageMenu } from ".";
+
+const meta: Meta<typeof MyPageMenu> = {
+  title: "Organisms/MyPageMenu",
+  component: MyPageMenu,
+  tags: ["autodocs"],
+  args: {
+    onMenuClick: (pathname) => console.log(pathname),
+  },
+};
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export default meta;

--- a/src/components/organisms/MyPageMenu/styled.ts
+++ b/src/components/organisms/MyPageMenu/styled.ts
@@ -1,0 +1,19 @@
+import styled from "@emotion/styled";
+
+export const MainMenuWrapper: ReturnType<typeof styled.div> = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+export const SubMenuWrapper: ReturnType<typeof styled.div> = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+`;
+
+export const MyPageMenuWrapper: ReturnType<typeof styled.div> = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;

--- a/src/constants/myPageMenus.ts
+++ b/src/constants/myPageMenus.ts
@@ -1,0 +1,34 @@
+import {
+  BanIcon,
+  BuyIcon,
+  MyLocationIcon,
+  NotificationIcon,
+  SellIcon,
+} from "components/atoms/Icon";
+import type { INavMenu } from "types";
+
+interface IMyPageMenus {
+  title: string; // 대제목
+  menus: INavMenu[]; // 하위 메뉴 목록
+}
+
+/**
+ * MyPage에서 사용되는 메뉴 목록
+ */
+export const MY_PAGE_MENUS: IMyPageMenus[] = [
+  {
+    title: "나의 거래",
+    menus: [
+      { icon: SellIcon, name: "판매 내역", pathname: "/sell" },
+      { icon: BuyIcon, name: "입찰 내역", pathname: "/buy" },
+    ],
+  },
+  {
+    title: "기타",
+    menus: [
+      { icon: MyLocationIcon, name: "동네 인증", pathname: "/my-location" },
+      { icon: NotificationIcon, name: "알림", pathname: "/notification" },
+      { icon: BanIcon, name: "차단 사용자 관리", pathname: "/ban" },
+    ],
+  },
+];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,3 @@
 export * from "./icon";
 export * from "./selectOption";
-
+export * from "./navMenu";

--- a/src/types/navMenu.d.ts
+++ b/src/types/navMenu.d.ts
@@ -1,0 +1,10 @@
+import type { IconType } from "./icon";
+
+/**
+ * 아이콘이 있는 메뉴 타입
+ */
+export interface INavMenu {
+  icon: IconType;
+  name: string;
+  pathname: string;
+}


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #45

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->

MyPageMenu 컴포넌트 개발했습니다.

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->

- 마이페이지에서 사용되는 메뉴 목록은 `constants/myPageMenus.ts`에서 관리합니다.
- icon / name / pathname을 사용하는 메뉴의 타입을 별도로 관리하는 것이 좋을 것 같아 `types/navMenu.d.ts`에 작성했습니다.
- key는 임의로 main menu쪽은 `m_root_${idx}`, sub menu쪽은 `m_${idx}_${i}`(부모 인덱스, 자식 인덱스)로 설정했습니다.

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

![image](https://github.com/user-attachments/assets/210a5972-7d47-4ae0-b737-64b6f3278f9c)
