### PR TITLE
feat: ChatItem 컴포넌트 개발

### DIFF
--- a/src/components/organisms/ChatItem/index.tsx
+++ b/src/components/organisms/ChatItem/index.tsx
@@ -1,0 +1,45 @@
+import { OverlappingImage } from "components/molecules";
+import { ChatItemWrapper } from "./styled";
+import { Badge, Text } from "components/atoms";
+import { getRelativeTime } from "utils";
+
+interface IChatItemProps {
+  profileImgUrl: string;
+  itemImgUrl: string;
+  name: string;
+  lastMsg: string;
+  lastMsgTime: string;
+  lastMsgCnt: number;
+  onClick: () => void;
+}
+
+export const ChatItem = ({
+  profileImgUrl,
+  itemImgUrl,
+  name,
+  lastMsg,
+  lastMsgTime,
+  lastMsgCnt,
+  onClick,
+}: IChatItemProps) => {
+  const lastMsgTimeStr = getRelativeTime(lastMsgTime);
+  return (
+    <ChatItemWrapper onClick={onClick}>
+      <div className="img-msg-con">
+        <OverlappingImage
+          frontImgUrl={itemImgUrl}
+          backImgUrl={profileImgUrl}
+          type="square"
+        ></OverlappingImage>
+        <div className="msg-con">
+          <Text content={name}></Text>
+          <Text content={lastMsg}></Text>
+        </div>
+      </div>
+      <div className="time-cnt-con">
+        <Text content={lastMsgTimeStr}></Text>
+        {lastMsgCnt > 0 && <Badge text={lastMsgCnt.toString()}></Badge>}
+      </div>
+    </ChatItemWrapper>
+  );
+};

--- a/src/components/organisms/ChatItem/stories.ts
+++ b/src/components/organisms/ChatItem/stories.ts
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ChatItem } from ".";
+
+const meta: Meta<typeof ChatItem> = {
+  title: "Organisms/ChatItem",
+  component: ChatItem,
+  tags: ["autodocs"],
+};
+
+type Story = StoryObj<typeof meta>;
+const commonArgs: {
+  profileImgUrl: string;
+  itemImgUrl: string;
+  name: string;
+  lastMsgTime: string;
+  onClick: () => void;
+} = {
+  profileImgUrl: "https://github.com/moypp.png",
+  itemImgUrl: "https://github.com/ppyom.png",
+  name: "username",
+  lastMsgTime: "2024-11-27T06:24:31:22",
+  onClick: () => {
+    console.log("chatItem 클릭");
+  },
+};
+
+export const Default: Story = {
+  args: {
+    ...commonArgs, // 공통 속성 복사
+    lastMsg: "last message",
+    lastMsgCnt: 1,
+  },
+};
+
+export const NoUnreadMsgState: Story = {
+  args: {
+    ...commonArgs, // 공통 속성 복사
+    lastMsg: "last message",
+    lastMsgCnt: 0,
+  },
+};
+
+export const MsgOverflowState: Story = {
+  args: {
+    ...commonArgs, // 공통 속성 복사
+    lastMsg: "last messageeeeeeeeeeeeeeee",
+    lastMsgCnt: 1,
+  },
+};
+
+export default meta;

--- a/src/components/organisms/ChatItem/styled.ts
+++ b/src/components/organisms/ChatItem/styled.ts
@@ -1,0 +1,36 @@
+import styled from "@emotion/styled";
+import { OverlappingImageContainer } from "components/molecules/OverlappingImage/styled";
+
+export const ChatItemWrapper: ReturnType<typeof styled.div> = styled.div`
+  max-width: 350px;
+  display: flex;
+  justify-content: space-between;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #eeeeee;
+  }
+  /* width를 주지 않으면 보이지 않아서 추가*/
+  ${OverlappingImageContainer} {
+    width: 55px;
+  }
+
+  .img-msg-con {
+    display: flex;
+    gap: 16px;
+    flex: 1;
+  }
+
+  .msg-con {
+    /* max-width 벗어나면 ... 처리 */
+    p {
+      white-space: nowrap;
+      overflow: hidden;
+      max-width: 200px;
+      text-overflow: ellipsis;
+    }
+  }
+
+  .time-cnt-con {
+  }
+`;


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #53 

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->
- last msg 길어지면 ... 처리
- lastMsgCnt 의 경우 0인 경우 Badge 컴포넌트 표출 X
- props로 전달 받은 profileImgUrl, itemImgUrl 이 Overlapping Image 컴포넌트에 전달 (Image 컴포넌트의 타입은 "square")
## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->
- 구분이 너무 안될 것 같아 hover 추가해뒀습니다.
- isActive 같은 것으로 active 상태가 필요하지 않을까 고민했는데 이 부분은 추후 디자인에서 필요하면 적용하는게 좋을 것 같습니다.
- `<OverlappingImage>` 컴포넌트가 width를 지정하지 않으면 출력이 안되는 것을 확인해서 사용하는 쪽에서 55px로 주었습니다.

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/b68170dc-0ead-4716-a83b-adfc4e500146)
![image](https://github.com/user-attachments/assets/f99e5d7e-0919-4c3e-96d0-25c7cfcaf266)
