### PR TITLE
feat: PostImageManager 컴포넌트 개발

### DIFF
--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -11,3 +11,4 @@ export { TabItem } from "./TabItem";
 export { TabMenu } from "./TabMenu";
 export { TextDividerList } from "./TextDividerList";
 export { TextWithImage } from "./TextWithImage";
+export { UploadedImageCounter } from "./UploadedImageCounter";

--- a/src/components/organisms/PostImageManager/index.tsx
+++ b/src/components/organisms/PostImageManager/index.tsx
@@ -1,0 +1,50 @@
+import { Fragment, useEffect, useState } from "react";
+import { UploadedImageCounter } from "components/molecules";
+import { PostImageItem } from "components/organisms";
+
+import { PostImageManagerWrapper, PostImageListWrapper } from "./styled";
+
+interface IPostImageManagerProps {
+  imgUrls: string[];
+  setImgUrls: React.Dispatch<React.SetStateAction<string[]>>;
+}
+
+export const PostImageManager = ({
+  imgUrls,
+  setImgUrls
+}: IPostImageManagerProps) => {
+  const onChange = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const url = e.target?.result;
+      if (typeof url === "string") {
+        setImgUrls((prev) => [...prev, url]);
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <PostImageManagerWrapper>
+      <UploadedImageCounter
+        text="사진 등록"
+        currentCount={imgUrls.length}
+        onChange={onChange}
+      />
+      <PostImageListWrapper>
+        {imgUrls.map((url, index) => (
+          <Fragment key={index}>
+            <PostImageItem
+              imgUrl={url}
+              isThumbnail={index === 0}
+              onClick={() => {
+                setImgUrls((prev) => prev.filter((_, i) => i !== index));
+              }}
+            />
+          </Fragment>
+        ))}
+      </PostImageListWrapper>
+    </PostImageManagerWrapper>
+  );
+};
+

--- a/src/components/organisms/PostImageManager/index.tsx
+++ b/src/components/organisms/PostImageManager/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useCallback } from "react";
 import { UploadedImageCounter } from "components/molecules";
 import { PostImageItem } from "components/organisms";
 
@@ -13,16 +13,26 @@ export const PostImageManager = ({
   imgUrls,
   setImgUrls
 }: IPostImageManagerProps) => {
-  const onChange = (file: File) => {
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const url = e.target?.result;
-      if (typeof url === "string") {
-        setImgUrls((prev) => [...prev, url]);
-      }
-    };
-    reader.readAsDataURL(file);
-  };
+  const onChange = useCallback(
+    (file: File) => {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const url = e.target?.result;
+        if (typeof url === "string") {
+          setImgUrls((prev) => [...prev, url]);
+        }
+      };
+      reader.readAsDataURL(file);
+    },
+    [setImgUrls]
+  );
+
+  const handleRemoveImage = useCallback(
+    (index: number) => {
+      setImgUrls((prev) => prev.filter((_, i) => i !== index));
+    },
+    [setImgUrls]
+  );
 
   return (
     <PostImageManagerWrapper>
@@ -37,9 +47,7 @@ export const PostImageManager = ({
             <PostImageItem
               imgUrl={url}
               isThumbnail={index === 0}
-              onClick={() => {
-                setImgUrls((prev) => prev.filter((_, i) => i !== index));
-              }}
+              onClick={() => handleRemoveImage(index)}
             />
           </Fragment>
         ))}

--- a/src/components/organisms/PostImageManager/index.tsx
+++ b/src/components/organisms/PostImageManager/index.tsx
@@ -1,51 +1,57 @@
-import { Fragment, useCallback } from "react";
+import { Fragment, useCallback, useEffect } from "react";
 import { UploadedImageCounter } from "components/molecules";
 import { PostImageItem } from "components/organisms";
 
 import { PostImageManagerWrapper, PostImageListWrapper } from "./styled";
+import { ImageInfo } from "types";
 
 interface IPostImageManagerProps {
-  imgUrls: string[];
-  setImgUrls: React.Dispatch<React.SetStateAction<string[]>>;
+  /** ImageInfo 배열 (url: S3에 업로드 된 이미지 url, base64Url: 아직 S3에 올라가지 않아서 미리보기만 제공되는 url, file: 아직 안올라간 이미지들을 나중에 S3에 올리기 위해 필요한 file)*/
+  imageInfos: ImageInfo[];
+  /** imageInfos를 설정하는 함수 */
+  setImageInfos: React.Dispatch<React.SetStateAction<ImageInfo[]>>;
 }
 
 export const PostImageManager = ({
-  imgUrls,
-  setImgUrls
+  imageInfos,
+  setImageInfos
 }: IPostImageManagerProps) => {
   const onChange = useCallback(
     (file: File) => {
       const reader = new FileReader();
       reader.onload = (e) => {
-        const url = e.target?.result;
-        if (typeof url === "string") {
-          setImgUrls((prev) => [...prev, url]);
-        }
+        const base64Url = e.target?.result as string;
+        const newImgData: ImageInfo = {
+          url: "",
+          base64Url,
+          file
+        };
+        setImageInfos((prev) => [...prev, newImgData]);
       };
       reader.readAsDataURL(file);
     },
-    [setImgUrls]
+    [setImageInfos]
   );
 
   const handleRemoveImage = useCallback(
     (index: number) => {
-      setImgUrls((prev) => prev.filter((_, i) => i !== index));
+      setImageInfos((prev) => prev.filter((_, i) => i !== index));
     },
-    [setImgUrls]
+    [setImageInfos]
   );
 
   return (
     <PostImageManagerWrapper>
       <UploadedImageCounter
         text="사진 등록"
-        currentCount={imgUrls.length}
+        currentCount={imageInfos.length}
         onChange={onChange}
       />
       <PostImageListWrapper>
-        {imgUrls.map((url, index) => (
+        {imageInfos.map((info, index) => (
           <Fragment key={index}>
             <PostImageItem
-              imgUrl={url}
+              imgUrl={(info.url || info.base64Url) as string}
               isThumbnail={index === 0}
               onClick={() => handleRemoveImage(index)}
             />

--- a/src/components/organisms/PostImageManager/stories.tsx
+++ b/src/components/organisms/PostImageManager/stories.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { PostImageManager } from ".";
+
+const meta: Meta<typeof PostImageManager> = {
+  title: "Organisms/PostImageManager",
+  component: PostImageManager,
+  tags: ["autodocs"],
+  argTypes: {
+    imgUrls: {
+      control: {
+        type: "object"
+      },
+      description: "이미지 URL 배열"
+    },
+    setImgUrls: {
+      action: "setImgUrls",
+      description: "이미지 URL 배열을 설정하는 함수"
+    }
+  }
+};
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => {
+    const Component = () => {
+      const [imgUrls, setImgUrls] = useState<string[]>([]);
+      return <PostImageManager imgUrls={imgUrls} setImgUrls={setImgUrls} />;
+    };
+    return <Component />;
+  }
+};
+
+export const ImageExist: Story = {
+  args: {
+    imgUrls: [
+      "https://github.com/moypp.png",
+      "https://github.com/ppyom.png",
+      "https://github.com/moypp.png",
+      "https://github.com/ppyom.png"
+    ]
+  },
+  render: (args) => {
+    const Component = () => {
+      const [imgUrls, setImgUrls] = useState<string[]>(args.imgUrls);
+      return <PostImageManager imgUrls={imgUrls} setImgUrls={setImgUrls} />;
+    };
+    return <Component />;
+  }
+};
+
+export default meta;
+

--- a/src/components/organisms/PostImageManager/stories.tsx
+++ b/src/components/organisms/PostImageManager/stories.tsx
@@ -1,21 +1,23 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { PostImageManager } from ".";
+import { ImageInfo } from "types";
 
 const meta: Meta<typeof PostImageManager> = {
   title: "Organisms/PostImageManager",
   component: PostImageManager,
   tags: ["autodocs"],
   argTypes: {
-    imgUrls: {
+    imageInfos: {
       control: {
         type: "object"
       },
-      description: "이미지 URL 배열"
+      description:
+        "ImageInfo 배열 (url: S3에 업로드 된 이미지 url, base64Url: 아직 S3에 올라가지 않아서 미리보기만 제공되는 url, file: 아직 안올라간 이미지들을 나중에 S3에 올리기 위해 필요한 file)"
     },
-    setImgUrls: {
-      action: "setImgUrls",
-      description: "이미지 URL 배열을 설정하는 함수"
+    setImageInfos: {
+      action: "setImageInfos",
+      description: "imageInfos를 설정하는 함수"
     }
   }
 };
@@ -25,8 +27,13 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: (args) => {
     const Component = () => {
-      const [imgUrls, setImgUrls] = useState<string[]>([]);
-      return <PostImageManager imgUrls={imgUrls} setImgUrls={setImgUrls} />;
+      const [imageInfos, setImageInfos] = useState<ImageInfo[]>([]);
+      return (
+        <PostImageManager
+          imageInfos={imageInfos}
+          setImageInfos={setImageInfos}
+        />
+      );
     };
     return <Component />;
   }
@@ -34,17 +41,24 @@ export const Default: Story = {
 
 export const ImageExist: Story = {
   args: {
-    imgUrls: [
-      "https://github.com/moypp.png",
-      "https://github.com/ppyom.png",
-      "https://github.com/moypp.png",
-      "https://github.com/ppyom.png"
+    imageInfos: [
+      { url: "https://github.com/moypp.png", base64Url: "", file: undefined },
+      { url: "https://github.com/ppyom.png", base64Url: "", file: undefined },
+      { url: "https://github.com/moypp.png", base64Url: "", file: undefined },
+      { url: "https://github.com/ppyom.png", base64Url: "", file: undefined }
     ]
   },
   render: (args) => {
     const Component = () => {
-      const [imgUrls, setImgUrls] = useState<string[]>(args.imgUrls);
-      return <PostImageManager imgUrls={imgUrls} setImgUrls={setImgUrls} />;
+      const [imageInfos, setImageInfos] = useState<ImageInfo[]>(
+        args.imageInfos
+      );
+      return (
+        <PostImageManager
+          imageInfos={imageInfos}
+          setImageInfos={setImageInfos}
+        />
+      );
     };
     return <Component />;
   }

--- a/src/components/organisms/PostImageManager/styled.ts
+++ b/src/components/organisms/PostImageManager/styled.ts
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+
+export const PostImageManagerWrapper: ReturnType<
+  typeof styled.div
+> = styled.div`
+  display: flex;
+`;
+
+export const PostImageListWrapper: ReturnType<typeof styled.div> = styled.div`
+  display: flex;
+`;
+

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -1,2 +1,3 @@
 export { Map } from "./Map";
+export { PostImageItem } from "./PostImageItem";
 export { SearchHistoryItem } from "./SearchHistoryItem";

--- a/src/types/image.d.ts
+++ b/src/types/image.d.ts
@@ -1,0 +1,5 @@
+export interface ImageInfo {
+  url?: string;
+  base64Url?: string;
+  file?: File;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from "./icon";
+export * from "./image";
 export * from "./map";
 export * from "./selectOption";
 export * from "./navMenu";


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #32 

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->
- PostImageManager 컴포넌트 개발
- ImageInfo를 props로 받아 처리하는 방식으로 구현
    - url: S3에 업로드 된 이미지 url ex) https://github.com/moypp.png
   - base64Url: 아직 S3에 올라가지 않아 미리보기만 제공하는 base64 url
   - file: 아직 올라가지 않은 이미지를 나중에 S3에 올리기 위해 필요한 file (S3에 올릴 때는 file을 사용한다고 하여 추가했습니다.)
```ts
export interface ImageInfo {
  url?: string;
  base64Url?: string;
  file?: File;
}
```


- console.log로 보면 이렇게 구성되었습니다.
![image](https://github.com/user-attachments/assets/118801c9-fdc4-40e1-84f9-d0e06fa2467c)
## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->
 - 이 방식으로 구현한 이유는 나중에 최종적으로 글을 등록할 때 남아있는 이미지들만 S3에 업로드하면 좋을 것 같아서 구현해봤습니다.
 - 일단 이렇게 구현했지만, 상위 컴포넌트 작업하시는 분이 마음대로 수정하시면 될 것 같습니다!
 
## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/8f64b742-641a-44b5-a90a-cc2febba347d)
![image](https://github.com/user-attachments/assets/014d2024-0790-437d-8d5a-7a4278c11989)
