### PR TITLE
feat: TransactionOverview 컴포넌트 개발

### DIFF
--- a/src/components/molecules/TabMenu/index.tsx
+++ b/src/components/molecules/TabMenu/index.tsx
@@ -6,13 +6,13 @@ interface ITabMenuProps {
   /** TabItem 리스트 */
   menus: string[];
   /** TabItem 클릭 이벤트  */
-  onClick: () => void;
+  onClick: (tab: string) => void;
 }
 
 export const TabMenu = ({ menus, onClick }: ITabMenuProps) => {
   const [currentIdx, setCurrentIdx] = useState(0);
   const handleTabMenu = (idx: number) => {
-    onClick();
+    onClick(menus[idx]);
     setCurrentIdx(idx);
   };
   return (

--- a/src/components/organisms/PostList/index.tsx
+++ b/src/components/organisms/PostList/index.tsx
@@ -26,9 +26,15 @@ export interface IPost {
   /** 아이콘 버튼 클릭 이벤트 */
   onIconButtonClick: () => void;
 }
+export type PostItemType =
+  | "completed"
+  | "default"
+  | "chat"
+  | "selling"
+  | "buying";
 interface IPostListProps {
   posts: IPost[];
-  type: "completed" | "default" | "chat" | "selling" | "buying";
+  type: PostItemType;
 }
 
 export const PostList = ({ posts, type }: IPostListProps) => {

--- a/src/components/organisms/TransactionOverview/index.tsx
+++ b/src/components/organisms/TransactionOverview/index.tsx
@@ -1,0 +1,28 @@
+import { TabMenu } from "components/molecules";
+import { TransactionOverviewWrapper } from "./styled";
+import { IPost, PostItemType, PostList } from "../PostList";
+
+interface ITransactionOverviewProps {
+  /** 탭 메뉴 title 리스트 */
+  menus: string[];
+  /** 탭 메뉴 클릭 이벤트 */
+  onClick: (tab: string) => void;
+  /** 현재 보여줄 post 리스트 */
+  posts: IPost[];
+  /** post 리스트의 type (PostList의 성격) */
+  type: PostItemType;
+}
+
+export const TransactionOverview = ({
+  menus,
+  onClick,
+  posts,
+  type,
+}: ITransactionOverviewProps) => {
+  return (
+    <TransactionOverviewWrapper>
+      <TabMenu menus={menus} onClick={onClick}></TabMenu>
+      <PostList posts={posts} type={type}></PostList>
+    </TransactionOverviewWrapper>
+  );
+};

--- a/src/components/organisms/TransactionOverview/stories.tsx
+++ b/src/components/organisms/TransactionOverview/stories.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { useEffect, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { TransactionOverview } from ".";
+import { IPost, PostItemType } from "../PostList";
+import { DEFAULT_IMG_PATH } from "constants/imgPath";
+
+const meta: Meta<typeof TransactionOverview> = {
+  title: "Organisms/TransactionOverview",
+  component: TransactionOverview,
+  tags: ["autodocs"],
+  argTypes: {
+    type: {
+      control: "radio",
+      options: ["selling", "buying", "completed"],
+    },
+  },
+};
+
+type Story = StoryObj<typeof TransactionOverview>; // 컴포넌트 타입 명시
+
+const tempPosts: IPost[] = Array.from({ length: 5 }, (_, index) => ({
+  productId: index + 1,
+  imgUrl: DEFAULT_IMG_PATH,
+  title: `물품 ${index + 1}`,
+  price: 3500 + index * 1000,
+  address: "신림동",
+  uploadTime: `2024-11-28 ${11 + index}:00:00`,
+  onClick: () => {
+    console.log(`클릭 ${index + 1}`);
+  },
+  expiredTime: `2024-12-29 ${11 + index}:00:00`,
+  maxPrice: 30000,
+  onTextButtonClick: () => {
+    console.log("Text Button 클릭");
+  },
+  onIconButtonClick: () => {
+    console.log("Icon Button 클릭");
+  },
+}));
+
+export const SellHistory: Story = {
+  args: {
+    menus: ["판매중", "거래완료"],
+    posts: tempPosts,
+    type: "selling",
+  },
+  render: (args) => {
+    const [type, setType] = useState<PostItemType>(args.type);
+
+    useEffect(() => {
+      setType(args.type);
+    }, [args.type]);
+
+    const handleTabClick = (tab: string) => {
+      const newType = tab === "판매중" ? "selling" : "completed";
+      setType(newType); // 상태 업데이트
+      console.log(`탭 클릭: ${tab}, type: ${newType}`);
+    };
+
+    return (
+      <TransactionOverview
+        {...args}
+        type={type} // 현재 상태의 type 전달
+        onClick={handleTabClick} // 탭 클릭 핸들러 설정
+      />
+    );
+  },
+};
+
+export const BuyHistory: Story = {
+  args: {
+    menus: ["입찰중", "거래완료"],
+    posts: tempPosts,
+    type: "buying",
+  },
+  render: (args) => {
+    const [type, setType] = useState<PostItemType>(args.type);
+
+    useEffect(() => {
+      setType(args.type);
+    }, [args.type]);
+
+    const handleTabClick = (tab: string) => {
+      const newType = tab === "입찰중" ? "buying" : "completed";
+      setType(newType); // 상태 업데이트
+      console.log(`탭 클릭: ${tab}, type: ${newType}`);
+    };
+
+    return (
+      <TransactionOverview
+        {...args}
+        type={type} // 현재 상태의 type 전달
+        onClick={handleTabClick} // 탭 클릭 핸들러 설정
+      />
+    );
+  },
+};
+export default meta;

--- a/src/components/organisms/TransactionOverview/styled.ts
+++ b/src/components/organisms/TransactionOverview/styled.ts
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled";
+
+export const TransactionOverviewWrapper: ReturnType<
+  typeof styled.div
+> = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+`;


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #46 

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->
- TransactionOverview 개발 완료
- Tab 클릭했을 때 PostList의 타입을 바꿀 수 있도록 TabMenu 의 onClick 타입을 변경하였습니다. #24
기존: () => void
변경 : (tab:string) => void  
## 🤔 참고 사항

- (1) 전체 post를 들고 있고, 내부적으로 판매중 / 거래 완료로 필터를 거는 방법과
(2) 판매중 Tab이나 거래완료 Tab 누를 때마다 fetch해오는 방식이 있는데
API 문서 확인하니(https://www.notion.so/prgrms/API-13d3e47046bf81238a6bfe177efb846d?p=13ef34660f81411fab029ba38186ef55&pm=s) 
(2)번 방법으로 진행하신 것 같아 (2)번 방법에 어울리도록 구성하였습니다.
<!-- 참고 사항을 설명해주세요 -->

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
![TransactionOverview](https://github.com/user-attachments/assets/0e62d2ad-69c1-42ae-a13c-f8a65fee283c)

