### PR TITLE
feat: MarketPriceTemplate 컴포넌트 개발

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -17,8 +17,8 @@ const preview: Preview = {
  * https://velog.io/@hyerimkimm/Storybook%EC%97%90%EC%84%9C-React-router-%EC%82%AC%EC%9A%A9-%EC%8B%9C-%EC%97%90%EB%9F%AC-%ED%95%B4%EA%B2%B0-%EB%B0%A9%EB%B2%95
  */
 export const decorators = [
-  (Story) => (
-    <MemoryRouter initialEntries={["/"]}>
+  (Story, context) => (
+    <MemoryRouter initialEntries={context.parameters.initialEntries || ["/"]}>
       <Story />
     </MemoryRouter>
   ),

--- a/src/components/templates/HomeTemplate/stories.ts
+++ b/src/components/templates/HomeTemplate/stories.ts
@@ -11,7 +11,7 @@ const meta: Meta<typeof HomeTemplate> = {
 
 type Story = StoryObj<typeof meta>;
 
-const tempPosts: IPost[] = Array.from({ length: 5 }, (_, index) => ({
+const tempPosts: IPost[] = Array.from({ length: 30 }, (_, index) => ({
   productId: index + 1,
   imgUrl: DEFAULT_IMG_PATH,
   title: `물품 ${index + 1}`,

--- a/src/components/templates/HomeTemplate/styled.ts
+++ b/src/components/templates/HomeTemplate/styled.ts
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { TextButtonWrapper } from "components/atoms/Button/TextButton/styled";
+import { BottomNavBarWrapper } from "components/organisms/BottomNavBar/styled";
 
 export const HomeTemplateWrapper: ReturnType<typeof styled.div> = styled.div`
   display: flex;
@@ -16,5 +17,10 @@ export const HomeTemplateWrapper: ReturnType<typeof styled.div> = styled.div`
 
   .post-con {
     flex: 1;
+    overflow-y: auto;
+  }
+
+  ${BottomNavBarWrapper} {
+    position: sticky;
   }
 `;

--- a/src/components/templates/MarketPriceTemplate/index.tsx
+++ b/src/components/templates/MarketPriceTemplate/index.tsx
@@ -1,0 +1,23 @@
+import { MarketPriceTemplateWrapper } from "./styled";
+import { IPost, PostList } from "components/organisms/PostList";
+import { EmptyTemplate } from "../EmptyTemplate";
+import { BottomNavBar } from "components/organisms";
+
+interface IMarketPriceTemplateProps {
+  posts: IPost[];
+}
+
+export const MarketPriceTemplate = ({ posts }: IMarketPriceTemplateProps) => {
+  return (
+    <MarketPriceTemplateWrapper>
+      <div className="post-con">
+        {posts.length === 0 ? (
+          <EmptyTemplate type={"default"}></EmptyTemplate>
+        ) : (
+          <PostList posts={posts} type={"default"}></PostList>
+        )}
+      </div>
+      <BottomNavBar></BottomNavBar>
+    </MarketPriceTemplateWrapper>
+  );
+};

--- a/src/components/templates/MarketPriceTemplate/stories.tsx
+++ b/src/components/templates/MarketPriceTemplate/stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { MarketPriceTemplate } from ".";
+import { DEFAULT_IMG_PATH } from "constants/imgPath";
+import { IPost } from "components/organisms/PostList";
+
+const meta: Meta<typeof MarketPriceTemplate> = {
+  title: "Templates/MarketPriceTemplate",
+  component: MarketPriceTemplate,
+  tags: ["autodocs"],
+};
+
+type Story = StoryObj<typeof meta>;
+
+const tempPosts: IPost[] = Array.from({ length: 30 }, (_, index) => ({
+  productId: index + 1,
+  imgUrl: DEFAULT_IMG_PATH,
+  title: `물품 ${index + 1}`,
+  price: 3500 + index * 1000, // 가격에 변화를 주기 위해 설정
+  address: "신림동",
+  uploadTime: `2024-11-28 ${11 + index}:00:00`, // 시간에 변화를 주기 위해 설정
+  onClick: () => {
+    console.log(`클릭 ${index + 1}`);
+  },
+  expiredTime: `2024-12-29 ${11 + index}:00:00`,
+  maxPrice: 30000,
+  onTextButtonClick: () => {
+    console.log("Text Button 클릭");
+  },
+  onIconButtonClick: () => {
+    console.log("Icon Button 클릭");
+  },
+}));
+
+export const Default: Story = {
+  args: {
+    posts: tempPosts,
+  },
+  parameters: {
+    initialEntries: ["/history"], // 스토리별 초기 URL 설정
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    posts: [],
+  },
+  parameters: {
+    initialEntries: ["/history"], // 스토리별 초기 URL 설정
+  },
+};
+export default meta;

--- a/src/components/templates/MarketPriceTemplate/styled.ts
+++ b/src/components/templates/MarketPriceTemplate/styled.ts
@@ -1,0 +1,19 @@
+import styled from "@emotion/styled";
+import { BottomNavBarWrapper } from "components/organisms/BottomNavBar/styled";
+
+export const MarketPriceTemplateWrapper: ReturnType<
+  typeof styled.div
+> = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+
+  .post-con {
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  ${BottomNavBarWrapper} {
+    position: sticky;
+  }
+`;


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #192 

## 💭 작업 내용
- 시세 조회 페이지 템플릿 작업
- post 개수가 많아지는 경우 BottomNavBar 고정이 안되는 현상을 발견해서 시세조회쪽이랑 홈쪽 둘 다 수정하였습니다.
- 현재 URL 정보를 제가 임의로 storybook 에 주기 위해 .storybook/preview.tsx 파일 수정하였습니다.
이에 따라 현재 url 정보를 스토리에 파라미터로 전달해줄 수 있습니다.
<!-- 작업한 내용을 간단히 설명해주세요 -->

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/aacba62d-951a-4c68-b953-f08f1e839a32)
![image](https://github.com/user-attachments/assets/91757acd-3f96-4e19-8068-70118b5ccf32)

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
