### PR TITLE
feat: RootLayout 컴포넌트 개발

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,14 @@ import { RouterProvider } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { router } from "router";
+import { GlobalStyle } from "styles";
 
 const queryClient: QueryClient = new QueryClient();
 
 const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
+      <GlobalStyle />
       <RouterProvider
         router={router}
         future={{

--- a/src/components/atoms/Icon/styled.ts
+++ b/src/components/atoms/Icon/styled.ts
@@ -7,8 +7,8 @@ export interface IIconProps {
 
 export const IconSizes = {
   s: "1rem",
-  m: "2rem",
-  l: "3rem",
+  m: "1.5rem",
+  l: "2rem",
 } as const;
 
 /**

--- a/src/components/organisms/BottomNavBar/index.tsx
+++ b/src/components/organisms/BottomNavBar/index.tsx
@@ -1,56 +1,29 @@
-import { NavBarItem } from "components/molecules/NavBarItem";
-import { BottomNavBarWrapper } from "./styled";
-import { BuyIcon } from "components/atoms/Icon";
 import { useLocation, useNavigate } from "react-router-dom";
+import { NavBarItem } from "components/molecules";
+import { BOTTOM_NAV_ITEMS } from "constants/bottomNavItems";
+import { BottomNavBarWrapper } from "./styled";
 
 export const BottomNavBar = () => {
   const navigate = useNavigate();
   const location = useLocation(); // 현재 URL 경로 가져오기
-  const buyIcon = BuyIcon;
   const isActive = (path: string) => location.pathname === path;
 
-  const handleHome = () => {
-    console.log("/ 로 이동");
-    navigate("/");
+  const handleNavBarItemClick = (path: string) => {
+    console.log(`${path} 로 이동`);
+    navigate(path);
   };
-  const handleHistory = () => {
-    console.log("/history 로 이동");
-    navigate("/history");
-  };
-  const handleChat = () => {
-    console.log("/chat 로 이동");
-    navigate("/chat");
-  };
-  const handleMyPage = () => {
-    console.log("/my-page 로 이동");
-    navigate("/my-page");
-  };
+
   return (
     <BottomNavBarWrapper>
-      <NavBarItem
-        state={isActive("/") ? "active" : "default"} // 조건에 따라 "active" 설정
-        title={"홈"}
-        icon={buyIcon}
-        onClick={handleHome}
-      ></NavBarItem>
-      <NavBarItem
-        state={isActive("/history") ? "active" : "default"}
-        title={"시세조회"}
-        icon={buyIcon}
-        onClick={handleHistory}
-      ></NavBarItem>
-      <NavBarItem
-        state={isActive("/chat") ? "active" : "default"}
-        title={"채팅"}
-        icon={buyIcon}
-        onClick={handleChat}
-      ></NavBarItem>
-      <NavBarItem
-        state={isActive("/my-page") ? "active" : "default"}
-        title={"My"}
-        icon={buyIcon}
-        onClick={handleMyPage}
-      ></NavBarItem>
+      {BOTTOM_NAV_ITEMS.map(({ path, title, icon }) => (
+        <NavBarItem
+          key={`bottom_nav_bar_${path}`}
+          state={isActive(path) ? "active" : "default"}
+          title={title}
+          icon={icon}
+          onClick={() => handleNavBarItemClick(path)}
+        />
+      ))}
     </BottomNavBarWrapper>
   );
 };

--- a/src/components/organisms/BottomNavBar/styled.ts
+++ b/src/components/organisms/BottomNavBar/styled.ts
@@ -4,6 +4,8 @@ import { NavBarItemWrapper } from "components/molecules/NavBarItem/styled";
 export const BottomNavBarWrapper: ReturnType<typeof styled.div> = styled.div`
   display: flex;
   justify-content: space-between;
+  background-color: #ffffff;
+  padding: 0.25rem 0;
   ${NavBarItemWrapper} {
     flex: 1;
   }

--- a/src/components/organisms/BottomNavBar/styled.ts
+++ b/src/components/organisms/BottomNavBar/styled.ts
@@ -1,6 +1,10 @@
 import styled from "@emotion/styled";
+import { NavBarItemWrapper } from "components/molecules/NavBarItem/styled";
 
 export const BottomNavBarWrapper: ReturnType<typeof styled.div> = styled.div`
   display: flex;
-  gap: 8px;
+  justify-content: space-between;
+  ${NavBarItemWrapper} {
+    flex: 1;
+  }
 `;

--- a/src/components/organisms/TopBar/index.tsx
+++ b/src/components/organisms/TopBar/index.tsx
@@ -24,6 +24,7 @@ const TopBarBackIcon = ({ onBackIconClick }: ITopBarBackIconProps) => {
   return (
     <TopBarBackIconWrapper>
       <IconButton
+        size="s"
         icon={BackIcon}
         onClick={onBackIconClick}
         backgroundColor="transparent"
@@ -43,6 +44,7 @@ const TopBarIcon = ({ icon, onIconClick }: ITopBarIconProps) => {
   return (
     <TopBarIconWrapper>
       <IconButton
+        size="s"
         icon={icon}
         onClick={onIconClick}
         backgroundColor="transparent"
@@ -57,7 +59,7 @@ interface ITopBarTitleProps {
 }
 
 const TopBarTitle = ({ title }: ITopBarTitleProps) => {
-  return <Text content={title} />;
+  return <Text variant="body1" content={title} />;
 };
 
 interface ITopBarInputProps {

--- a/src/components/organisms/TopBar/styled.ts
+++ b/src/components/organisms/TopBar/styled.ts
@@ -1,30 +1,36 @@
 import styled from "@emotion/styled";
 import { InputWrapper } from "components/atoms/Input/styled";
+import { Body1Wrapper } from "components/atoms/Text/styled";
 
-const CommonIconWrapper: ReturnType<typeof styled.div> = styled.div`
-  position: absolute;
-  top: 50%;
-  translate: 0 -50%;
-`;
+const CommonIconWrapper: ReturnType<typeof styled.div> = styled.div``;
 export const TopBarBackIconWrapper: typeof CommonIconWrapper = styled(
   CommonIconWrapper,
-)`
-  left: 1rem;
-`;
+)``;
 export const TopBarIconWrapper: typeof CommonIconWrapper = styled(
   CommonIconWrapper,
-)`
-  right: 1rem;
-`;
+)``;
 
 export const TopBarWrapper: ReturnType<typeof styled.div> = styled.div`
   display: flex;
   justify-content: center;
-  background-color: #e9e9e9;
+  align-items: center;
+  background-color: #ffffff;
   position: relative;
-  padding: 1rem 0;
+  padding: 0.5rem 1rem;
+  gap: 0.5rem;
+  & > ${Body1Wrapper} {
+    flex: 1;
+    padding: 0.5rem;
+    text-align: center;
+  }
   & > ${InputWrapper} {
     flex: 1;
-    margin: 0 4.5rem;
+    height: auto;
+    padding: 0.5rem 1rem;
+    background-color: #eee;
+  }
+  &:has(${InputWrapper}) ${TopBarIconWrapper} {
+    position: absolute;
+    right: 1.5rem;
   }
 `;

--- a/src/components/templates/RootLayout/index.tsx
+++ b/src/components/templates/RootLayout/index.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useMemo } from "react";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { Header, BottomNavBar, TopBar } from "components/organisms";
+import { useHeaderStore, useTopBarStore } from "stores";
+import { PageLayoutWrapper, RootLayoutWrapper } from "./styled";
+
+export const RootLayout = () => {
+  const navigate = useNavigate();
+  const { pathname: _pathname } = useLocation();
+  const { title: headerTitle } = useHeaderStore();
+  const {
+    title: topBarTitle,
+    icon,
+    onBackClick,
+    onRightClick,
+    setValue,
+    value,
+    setBackClick,
+    clear,
+  } = useTopBarStore();
+  /**
+   * 현재 페이지 체크 시 사용되는 pathname
+   * 첫 번째 path만 사용
+   */
+  const pathname = useMemo(() => `/${_pathname.split("/")[1]}`, [_pathname]);
+
+  /**
+   * 알림
+   */
+  const handleNotificationButtonClick = () => {
+    navigate("/notification");
+  };
+  /**
+   * 검색
+   */
+  const handleSearchButtonClick = () => {
+    navigate("/search");
+  };
+  /**
+   * 동네 선택
+   */
+  const handleLocationButtonClick = () => {
+    navigate("/neighborhood-selection");
+  };
+  /**
+   * 뒤로가기
+   */
+  const handleBackButtonClick = () => {
+    navigate(-1);
+  };
+
+  /** backIcon 클릭 기본 함수 지정 */
+  useEffect(() => {
+    setBackClick(handleBackButtonClick);
+  }, []);
+
+  /** search 이외에서 RightIcon / Title 초기화 */
+  useEffect(() => {
+    if (pathname !== "/search") {
+      clear();
+    }
+  }, [pathname]);
+
+  return (
+    <RootLayoutWrapper>
+      {["/", "/market-price", "/chat", "/my-page"].includes(pathname) && (
+        <Header
+          type={pathname === "/" ? "home" : "default"}
+          title={headerTitle}
+          onNotificationClick={handleNotificationButtonClick}
+          onSearchClick={handleSearchButtonClick}
+          onLocationClick={handleLocationButtonClick}
+        />
+      )}
+      {!["/", "/market-price", "/chat", "/my-page"].includes(pathname) && (
+        <TopBar>
+          <TopBar.BackIcon onBackIconClick={onBackClick} />
+          {!["/search"].includes(pathname) && (
+            <TopBar.Title title={topBarTitle} />
+          )}
+          {["/search"].includes(pathname) && (
+            <TopBar.Input value={value} setValue={setValue} />
+          )}
+          {icon && onRightClick && (
+            <TopBar.Icon icon={icon} onIconClick={onRightClick} />
+          )}
+        </TopBar>
+      )}
+      <PageLayoutWrapper>
+        <Outlet />
+      </PageLayoutWrapper>
+      {["/", "/market-price", "/chat", "/my-page"].includes(pathname) && (
+        <BottomNavBar />
+      )}
+    </RootLayoutWrapper>
+  );
+};

--- a/src/components/templates/RootLayout/styled.ts
+++ b/src/components/templates/RootLayout/styled.ts
@@ -1,0 +1,27 @@
+import styled from "@emotion/styled";
+import { HeaderWrapper } from "components/organisms/Header/styled";
+import { TopBarWrapper } from "components/organisms/TopBar/styled";
+import { BottomNavBarWrapper } from "components/organisms/BottomNavBar/styled";
+
+export const PageLayoutWrapper: ReturnType<typeof styled.div> = styled.div`
+  flex: 1;
+  background-color: #ffffff;
+`;
+
+export const RootLayoutWrapper: ReturnType<typeof styled.div> = styled.div`
+  min-height: 100vh;
+  max-width: 375px;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  ${HeaderWrapper}, ${TopBarWrapper} {
+    position: sticky;
+    top: 0;
+  }
+  ${BottomNavBarWrapper} {
+    position: sticky;
+    bottom: 0;
+  }
+`;

--- a/src/components/templates/index.ts
+++ b/src/components/templates/index.ts
@@ -1,0 +1,1 @@
+export { RootLayout } from "./RootLayout";

--- a/src/constants/bottomNavItems.ts
+++ b/src/constants/bottomNavItems.ts
@@ -1,0 +1,13 @@
+import {
+  ChatIcon,
+  HomeIcon,
+  MarketPriceIcon,
+  MyPageIcon,
+} from "components/atoms/Icon";
+
+export const BOTTOM_NAV_ITEMS = [
+  { title: "홈", path: "/", icon: HomeIcon },
+  { title: "시세조회", path: "/market-price", icon: MarketPriceIcon },
+  { title: "채팅", path: "/chat", icon: ChatIcon },
+  { title: "My", path: "/my-page", icon: MyPageIcon },
+] as const;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from "./useMap";
 export * from "./useTimeoutFn";
 export * from "./useTimeout";
 export * from "./useRemainingTimer";
+export * from "./useSearchTopBar";

--- a/src/hooks/useSearchTopBar.ts
+++ b/src/hooks/useSearchTopBar.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { SearchIcon } from "components/atoms/Icon";
+import { useTopBarStore } from "stores";
+
+/**
+ * SearchTopBar가 필요한 페이지(search, searchResult)에서 사용하는 hook
+ * @param value searchTerm의 기본 값 (default: "")
+ */
+export const useSearchTopBar = (value: string = "") => {
+  const navigate = useNavigate();
+  const [searchTerm, setSearchTerm] = useState(value);
+  const { setSearchBar, setIcon, setRightClick } = useTopBarStore();
+
+  /**
+   * 검색 페이지로 이동하는 함수
+   */
+  const handleSearch = () => {
+    console.log(searchTerm);
+    navigate(`/search/${searchTerm}`);
+  };
+
+  useEffect(() => {
+    setSearchBar(searchTerm, setSearchTerm);
+    setIcon(SearchIcon);
+    setRightClick(handleSearch);
+  }, []);
+
+  return {
+    setSearchTerm,
+  };
+};

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,3 +1,12 @@
+import { useEffect } from "react";
+import { useHeaderStore } from "stores";
+
 export const HomePage = () => {
+  const { setTitle } = useHeaderStore();
+
+  useEffect(() => {
+    setTitle("신림동"); // 동네 이름 받아서 처리 필요
+  }, []);
+
   return <>HomePage</>;
 };

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,3 +1,7 @@
+import { useSearchTopBar } from "hooks";
+
 export const SearchPage = () => {
+  useSearchTopBar();
+
   return <>SearchPage</>;
 };

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -1,3 +1,14 @@
+import { useEffect } from "react";
+import { useSearchTopBar } from "hooks";
+import { useParams } from "react-router-dom";
+
 export const SearchResultPage = () => {
+  const { query } = useParams<{ query: string }>();
+  const { setSearchTerm } = useSearchTopBar(query);
+
+  useEffect(() => {
+    setSearchTerm(query!);
+  }, [query]);
+
   return <>SearchResultPage</>;
 };

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,8 +1,4 @@
-import {
-  createBrowserRouter,
-  Outlet,
-  type RouteObject,
-} from "react-router-dom";
+import { createBrowserRouter, type RouteObject } from "react-router-dom";
 import {
   BlockedUsersPage,
   CategoryPage,
@@ -23,16 +19,12 @@ import {
   TransactionLocationPage,
   TransactionPage,
 } from "pages";
+import { RootLayout } from "components/templates";
 
 export const routes: RouteObject[] = [
   {
     path: "/",
-    element: (
-      // RootLayout
-      <>
-        <Outlet />
-      </>
-    ),
+    element: <RootLayout />,
     errorElement: <>404</>,
     children: [
       // home

--- a/src/stores/headerStore.ts
+++ b/src/stores/headerStore.ts
@@ -1,0 +1,12 @@
+import { create, type StoreApi, type UseBoundStore } from "zustand";
+
+interface HeaderState {
+  title: string;
+  setTitle: (title: string) => void;
+}
+
+export const useHeaderStore: UseBoundStore<StoreApi<HeaderState>> =
+  create<HeaderState>((set) => ({
+    title: "",
+    setTitle: (title) => set({ title }),
+  }));

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,2 @@
+export { useHeaderStore } from "./headerStore";
+export { useTopBarStore } from "./topbarStore";

--- a/src/stores/topbarStore.ts
+++ b/src/stores/topbarStore.ts
@@ -1,0 +1,43 @@
+import { create, type StoreApi, type UseBoundStore } from "zustand";
+import type { IconType } from "types";
+
+interface TopBarState {
+  // States
+  title: string;
+  onBackClick: () => void;
+  value: string;
+  setValue: (value: string) => void;
+  icon?: IconType;
+  onRightClick?: () => void;
+  // SetActions
+  setTitle: (title: string) => void;
+  setBackClick: (backClick: () => void) => void;
+  setSearchBar: (value: string, setValue: (value: string) => void) => void;
+  setIcon: (icon: IconType) => void;
+  setRightClick: (rightClick: () => void) => void;
+  clear: () => void;
+}
+
+export const defaultState: Pick<
+  TopBarState,
+  "title" | "icon" | "onRightClick"
+> = {
+  title: "",
+  icon: undefined,
+  onRightClick: undefined,
+};
+
+export const useTopBarStore: UseBoundStore<StoreApi<TopBarState>> =
+  create<TopBarState>((set, get) => ({
+    ...defaultState,
+    value: "",
+    setValue: () => {},
+    onBackClick: () => {},
+    //
+    setTitle: (title) => set({ ...get(), title }),
+    setBackClick: (backClick) => set({ onBackClick: backClick }),
+    setSearchBar: (value, setValue) => set({ ...get(), value, setValue }),
+    setIcon: (icon) => set({ ...get(), icon }),
+    setRightClick: (rightClick) => set({ ...get(), onRightClick: rightClick }),
+    clear: () => set({ ...get(), ...defaultState }),
+  }));

--- a/src/styles/global.tsx
+++ b/src/styles/global.tsx
@@ -1,0 +1,20 @@
+import { css, Global } from "@emotion/react";
+
+export const GlobalStyle = () => {
+  return (
+    <Global
+      styles={() => css`
+        // Font
+        // ...
+        // RootContainer
+        body {
+          background-color: #212121; // 임시
+        }
+        #root {
+          display: flex;
+          justify-content: center;
+        }
+      `}
+    />
+  );
+};

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,0 +1,1 @@
+export { GlobalStyle } from "./global";


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #159

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->

RootLayout 컴포넌트 개발했습니다.

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->

- 초기화 스타일 이외의 공통 스타일 적용을 위해 GlobalStyle 컴포넌트를 만들었습니다.
- RootLayout의 max-width는 375px입니다.
- 각 페이지에서 Header와 TopBar 사용 방법은 Home, Search, SearchResult(useSearchTopBar) 페이지에 적용해두었습니다.
    - Header를 사용할 때에는 useHeaderStore의 setTitle을 호출해서 사용합니다.
    - TopBar를 사용하는 페이지에서는 useTopBarStore의 각 Set Action(setIcon, setRightClick, setBackClick => default navigate(-1)) 함수들을 호출해서 사용합니다.
    - 기본적으로 search에서는 SearchTopBar를 사용하기 때문에 해당 로직은 useSearchTopBar로 분리해두었습니다.

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

![image](https://github.com/user-attachments/assets/f3618c3d-8cdc-4b82-a46a-051d29f185f8)
