### PR TITLE
feat: PermissionRequestTemplate 컴포넌트 개발

### DIFF
--- a/src/components/organisms/PermissionList/styled.ts
+++ b/src/components/organisms/PermissionList/styled.ts
@@ -1,15 +1,17 @@
 import styled from "@emotion/styled";
 
 export const PermissionListWrapper: ReturnType<typeof styled.div> = styled.div`
-  width: 375px;
+  height: 100%;
+
   white-space: pre-line;
 
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   gap: 64px;
 
   .permission-con {
-    min-height: 350px;
+    flex: 1;
     display: flex;
     flex-direction: column;
     gap: 16px;

--- a/src/components/templates/PermissionRequestTemplate/index.tsx
+++ b/src/components/templates/PermissionRequestTemplate/index.tsx
@@ -1,0 +1,21 @@
+import {
+  type IPermission,
+  PermissionList,
+} from "components/organisms/PermissionList";
+import { PermissionRequestTemplateWrapper } from "./styled";
+
+interface IPermissionRequestTemplateProps {
+  permissions: IPermission[];
+  onClick: () => void;
+}
+
+export const PermissionRequestTemplate = ({
+  permissions,
+  onClick,
+}: IPermissionRequestTemplateProps) => {
+  return (
+    <PermissionRequestTemplateWrapper>
+      <PermissionList permissions={permissions} onClick={onClick} />
+    </PermissionRequestTemplateWrapper>
+  );
+};

--- a/src/components/templates/PermissionRequestTemplate/index.tsx
+++ b/src/components/templates/PermissionRequestTemplate/index.tsx
@@ -5,7 +5,9 @@ import {
 import { PermissionRequestTemplateWrapper } from "./styled";
 
 interface IPermissionRequestTemplateProps {
+  /** 권한 목록 */
   permissions: IPermission[];
+  /** 확인 버튼 클릭 시 실행될 함수 */
   onClick: () => void;
 }
 

--- a/src/components/templates/PermissionRequestTemplate/stories.ts
+++ b/src/components/templates/PermissionRequestTemplate/stories.ts
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LocationIcon, NotificationIcon } from "components/atoms/Icon";
+import { PermissionRequestTemplate } from ".";
+
+const meta: Meta<typeof PermissionRequestTemplate> = {
+  title: "Templates/PermissionRequestTemplate",
+  component: PermissionRequestTemplate,
+  tags: ["autodocs"],
+};
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    permissions: [
+      {
+        icon: LocationIcon,
+        content: "위치",
+        desc: "어디에서 사용되는지 작성",
+      },
+      {
+        icon: NotificationIcon,
+        content: "알림",
+        desc: "어디에서 사용되는지 작성",
+      },
+    ],
+    onClick: () => {
+      console.log("확인 버튼 클릭");
+    },
+  },
+};
+
+export default meta;

--- a/src/components/templates/PermissionRequestTemplate/styled.ts
+++ b/src/components/templates/PermissionRequestTemplate/styled.ts
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+
+export const PermissionRequestTemplateWrapper: ReturnType<typeof styled.div> =
+  styled.div`
+    flex: 1;
+    padding: 2rem 1rem 1rem;
+  `;

--- a/src/components/templates/RootLayout/styled.ts
+++ b/src/components/templates/RootLayout/styled.ts
@@ -6,6 +6,7 @@ import { BottomNavBarWrapper } from "components/organisms/BottomNavBar/styled";
 export const PageLayoutWrapper: ReturnType<typeof styled.div> = styled.div`
   flex: 1;
   background-color: #ffffff;
+  display: flex;
 `;
 
 export const RootLayoutWrapper: ReturnType<typeof styled.div> = styled.div`


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #163
- #57 

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->

PermissionRequestTemplate 컴포넌트 개발했습니다.

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->

- 공통 레이아웃 스타일의 PageLayoutWrapper에 display: flex를 추가했습니다. (전체 사이즈를 차지하는 경우를 처리하기 위함 => [참고한 코드](https://codepen.io/dshung1997/pen/LYxvXNy))
- PermissionList의 스타일을 변경했습니다.
    - 기존에 375px로 고정된 부분 제거 (이후 공통 레이아웃에서 처리됨)
    - height 100%, justify-content space-between
    - permission-con의 min-height를 제거하고 flex-1 추가

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

![image](https://github.com/user-attachments/assets/776a603a-2163-4e45-a991-3c8ebd356605)

