### PR TITLE
fix: TopBar 수정

### DIFF
--- a/src/components/atoms/Icon/NoIcon/index.tsx
+++ b/src/components/atoms/Icon/NoIcon/index.tsx
@@ -1,0 +1,13 @@
+import { type IIconProps, IconWrapper } from "../styled";
+import { NoIconWrapper } from "./styled";
+
+/**
+ * 비어있는 아이콘
+ */
+export const NoIcon = ({ size = "m" }: IIconProps) => {
+  return (
+    <IconWrapper size={size}>
+      <NoIconWrapper size={size} />
+    </IconWrapper>
+  );
+};

--- a/src/components/atoms/Icon/NoIcon/stories.ts
+++ b/src/components/atoms/Icon/NoIcon/stories.ts
@@ -1,0 +1,35 @@
+import { type Meta, StoryObj } from "@storybook/react";
+import { NoIcon } from ".";
+import { IconSizes } from "../styled";
+
+const meta: Meta<typeof NoIcon> = {
+  title: "Atoms/Icon/NoIcon",
+  component: NoIcon,
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "select",
+      options: Object.keys(IconSizes),
+    },
+  },
+};
+
+type Story = StoryObj<typeof meta>;
+
+export const small: Story = {
+  args: {
+    size: "s",
+  },
+};
+export const medium: Story = {
+  args: {
+    size: "m",
+  },
+};
+export const large: Story = {
+  args: {
+    size: "l",
+  },
+};
+
+export default meta;

--- a/src/components/atoms/Icon/NoIcon/styled.ts
+++ b/src/components/atoms/Icon/NoIcon/styled.ts
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled";
+import { IconSizes, type IIconProps } from "../styled";
+
+export const NoIconWrapper: ReturnType<typeof styled.span<IIconProps>> =
+  styled.span<IIconProps>`
+    display: inline-block;
+    width: ${({ size }) => IconSizes[size!]};
+    height: ${({ size }) => IconSizes[size!]};
+  `;

--- a/src/components/atoms/Icon/index.ts
+++ b/src/components/atoms/Icon/index.ts
@@ -18,3 +18,4 @@ export { MarketPriceIcon } from "./MarketPriceIcon";
 export { ChatIcon } from "./ChatIcon";
 export { MyPageIcon } from "./MyPageIcon";
 export { DownIcon } from "./DownIcon";
+export { NoIcon } from "./NoIcon";

--- a/src/components/organisms/TopBar/index.tsx
+++ b/src/components/organisms/TopBar/index.tsx
@@ -1,5 +1,5 @@
 import { IconButton, Input, Text } from "components/atoms";
-import { BackIcon } from "components/atoms/Icon";
+import { BackIcon, NoIcon } from "components/atoms/Icon";
 import type { IconType } from "types";
 import {
   TopBarBackIconWrapper,
@@ -35,12 +35,12 @@ const TopBarBackIcon = ({ onBackIconClick }: ITopBarBackIconProps) => {
 
 interface ITopBarIconProps {
   /** 우측 아이콘 컴포넌트 */
-  icon: IconType;
+  icon?: IconType;
   /** 우측 아이콘 클릭 함수 */
-  onIconClick: () => void;
+  onIconClick?: () => void;
 }
 
-const TopBarIcon = ({ icon, onIconClick }: ITopBarIconProps) => {
+const TopBarIcon = ({ icon = NoIcon, onIconClick }: ITopBarIconProps) => {
   return (
     <TopBarIconWrapper>
       <IconButton

--- a/src/components/organisms/TopBar/stories.tsx
+++ b/src/components/organisms/TopBar/stories.tsx
@@ -49,9 +49,7 @@ export const Default: Story = {
       <TopBar>
         <TopBar.BackIcon onBackIconClick={args.onBackIconClick} />
         <TopBar.Title title={args.title} />
-        {args.icon && (
-          <TopBar.Icon icon={args.icon} onIconClick={args.onIconClick} />
-        )}
+        <TopBar.Icon icon={args.icon} onIconClick={args.onIconClick} />
       </TopBar>
     );
   },

--- a/src/components/organisms/TopBar/styled.ts
+++ b/src/components/organisms/TopBar/styled.ts
@@ -1,6 +1,8 @@
 import styled from "@emotion/styled";
 import { InputWrapper } from "components/atoms/Input/styled";
 import { Body1Wrapper } from "components/atoms/Text/styled";
+import { NoIconWrapper } from "components/atoms/Icon/NoIcon/styled";
+import { IconButtonWrapper } from "components/atoms/Button/IconButton/styled";
 
 const CommonIconWrapper: ReturnType<typeof styled.div> = styled.div``;
 export const TopBarBackIconWrapper: typeof CommonIconWrapper = styled(
@@ -8,7 +10,11 @@ export const TopBarBackIconWrapper: typeof CommonIconWrapper = styled(
 )``;
 export const TopBarIconWrapper: typeof CommonIconWrapper = styled(
   CommonIconWrapper,
-)``;
+)`
+  ${IconButtonWrapper}:has(${NoIconWrapper}) {
+    cursor: default;
+  }
+`;
 
 export const TopBarWrapper: ReturnType<typeof styled.div> = styled.div`
   display: flex;

--- a/src/components/templates/RootLayout/index.tsx
+++ b/src/components/templates/RootLayout/index.tsx
@@ -16,7 +16,6 @@ export const RootLayout = () => {
     setValue,
     value,
     setBackClick,
-    clear,
   } = useTopBarStore();
   /**
    * 현재 페이지 체크 시 사용되는 pathname
@@ -54,13 +53,6 @@ export const RootLayout = () => {
     setBackClick(handleBackButtonClick);
   }, []);
 
-  /** search 이외에서 RightIcon / Title 초기화 */
-  useEffect(() => {
-    if (pathname !== "/search") {
-      clear();
-    }
-  }, [pathname]);
-
   return (
     <RootLayoutWrapper>
       {["/", "/market-price", "/chat", "/my-page"].includes(pathname) && (
@@ -88,9 +80,7 @@ export const RootLayout = () => {
           {["/search"].includes(pathname) && (
             <TopBar.Input value={value} setValue={setValue} />
           )}
-          {icon && onRightClick && (
-            <TopBar.Icon icon={icon} onIconClick={onRightClick} />
-          )}
+          <TopBar.Icon icon={icon} onIconClick={onRightClick} />
         </TopBar>
       )}
       <PageLayoutWrapper>

--- a/src/components/templates/RootLayout/index.tsx
+++ b/src/components/templates/RootLayout/index.tsx
@@ -15,6 +15,7 @@ export const RootLayout = () => {
     onRightClick,
     setValue,
     value,
+    placeholder,
     setBackClick,
   } = useTopBarStore();
   /**
@@ -78,7 +79,11 @@ export const RootLayout = () => {
             <TopBar.Title title={topBarTitle} />
           )}
           {["/search"].includes(pathname) && (
-            <TopBar.Input value={value} setValue={setValue} />
+            <TopBar.Input
+              value={value}
+              setValue={setValue}
+              placeholder={placeholder}
+            />
           )}
           <TopBar.Icon icon={icon} onIconClick={onRightClick} />
         </TopBar>

--- a/src/hooks/useSearchTopBar.ts
+++ b/src/hooks/useSearchTopBar.ts
@@ -21,7 +21,7 @@ export const useSearchTopBar = (value: string = "") => {
   };
 
   useEffect(() => {
-    setSearchBar(searchTerm, setSearchTerm);
+    setSearchBar(searchTerm, setSearchTerm, "검색어를 입력해주세요.");
     setRightIcon(SearchIcon, handleSearch);
   }, []);
 

--- a/src/hooks/useSearchTopBar.ts
+++ b/src/hooks/useSearchTopBar.ts
@@ -10,7 +10,7 @@ import { useTopBarStore } from "stores";
 export const useSearchTopBar = (value: string = "") => {
   const navigate = useNavigate();
   const [searchTerm, setSearchTerm] = useState(value);
-  const { setSearchBar, setIcon, setRightClick } = useTopBarStore();
+  const { setSearchBar, setRightIcon } = useTopBarStore();
 
   /**
    * 검색 페이지로 이동하는 함수
@@ -22,8 +22,7 @@ export const useSearchTopBar = (value: string = "") => {
 
   useEffect(() => {
     setSearchBar(searchTerm, setSearchTerm);
-    setIcon(SearchIcon);
-    setRightClick(handleSearch);
+    setRightIcon(SearchIcon, handleSearch);
   }, []);
 
   return {

--- a/src/stores/topbarStore.ts
+++ b/src/stores/topbarStore.ts
@@ -7,12 +7,17 @@ interface TopBarState {
   onBackClick: () => void;
   value: string;
   setValue: (value: string) => void;
+  placeholder?: string;
   icon?: IconType;
   onRightClick?: () => void;
   // SetActions
   setTitle: (title: string) => void;
   setBackClick: (backClick: () => void) => void;
-  setSearchBar: (value: string, setValue: (value: string) => void) => void;
+  setSearchBar: (
+    value: string,
+    setValue: (value: string) => void,
+    placeholder?: string,
+  ) => void;
   setRightIcon: (icon: IconType, onClick: () => void) => void;
   clear: () => void;
 }
@@ -27,12 +32,14 @@ export const useTopBarStore: UseBoundStore<StoreApi<TopBarState>> =
     ...defaultState,
     title: "",
     value: "",
+    placeholder: "",
     setValue: () => {},
     onBackClick: () => {},
     //
     setTitle: (title) => set({ ...get(), title }),
     setBackClick: (backClick) => set({ onBackClick: backClick }),
-    setSearchBar: (value, setValue) => set({ ...get(), value, setValue }),
+    setSearchBar: (value, setValue, placeholder = "") =>
+      set({ ...get(), value, setValue, placeholder }),
     setRightIcon: (icon, onClick) =>
       set({ ...get(), icon, onRightClick: onClick }),
     clear: () => set({ ...get(), ...defaultState }),

--- a/src/stores/topbarStore.ts
+++ b/src/stores/topbarStore.ts
@@ -13,16 +13,11 @@ interface TopBarState {
   setTitle: (title: string) => void;
   setBackClick: (backClick: () => void) => void;
   setSearchBar: (value: string, setValue: (value: string) => void) => void;
-  setIcon: (icon: IconType) => void;
-  setRightClick: (rightClick: () => void) => void;
+  setRightIcon: (icon: IconType, onClick: () => void) => void;
   clear: () => void;
 }
 
-export const defaultState: Pick<
-  TopBarState,
-  "title" | "icon" | "onRightClick"
-> = {
-  title: "",
+export const defaultState: Pick<TopBarState, "icon" | "onRightClick"> = {
   icon: undefined,
   onRightClick: undefined,
 };
@@ -30,6 +25,7 @@ export const defaultState: Pick<
 export const useTopBarStore: UseBoundStore<StoreApi<TopBarState>> =
   create<TopBarState>((set, get) => ({
     ...defaultState,
+    title: "",
     value: "",
     setValue: () => {},
     onBackClick: () => {},
@@ -37,7 +33,7 @@ export const useTopBarStore: UseBoundStore<StoreApi<TopBarState>> =
     setTitle: (title) => set({ ...get(), title }),
     setBackClick: (backClick) => set({ onBackClick: backClick }),
     setSearchBar: (value, setValue) => set({ ...get(), value, setValue }),
-    setIcon: (icon) => set({ ...get(), icon }),
-    setRightClick: (rightClick) => set({ ...get(), onRightClick: rightClick }),
+    setRightIcon: (icon, onClick) =>
+      set({ ...get(), icon, onRightClick: onClick }),
     clear: () => set({ ...get(), ...defaultState }),
   }));


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #215 

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->

TopBar 컴포넌트를 수정했습니다.

Template를 페이지에 넣어보며 테스트하던 중 TopBar 모양이 깨지는 것을 확인했고, 고치려고 만지다가 RootLayout에 넣은 clear 함수때문에 계속해서 TopBar가 초기화되는 현상을 확인해 해당 이슈를 수정했습니다.

또한 살짝 불편하다고 느낀 우측 아이콘 설정 함수들을 하나로 묶었습니다.

### TopBar 스타일 수정

![image](https://github.com/user-attachments/assets/9813ce35-e221-4eef-b3c1-0fcfbe49d445)

기존에 icon이 없다면 RightIcon을 아예 보여주지 않아 backIcon, title만 있을 때 이상하게 보였습니다. 

해당 스타일을 고치기 위해 `NoIcon`이라는 아무것도 없는 아이콘을 추가해 rightIcon이 기본적으로 해당 아이콘을 갖도록 수정했습니다.

![image](https://github.com/user-attachments/assets/fb6abb38-1542-4230-b64c-944d8f50705d)

### clear 함수 문제

RootLayout에서 pathname이 변경될 때마다 TopBar를 초기화하도록 만들었는데 해당 함수가 의도한대로(초기화 -> 화면에서 setTitle.....) 동작하지 않아 제거했습니다.

이후 해당 함수는 사용될 수 있을 것 같아 제거하진 않고, rightIcon의 icon과 onRightClick의 값을 초기화하는 함수로 변경했습니다. (기존에는 title도 초기화)

### right icon 설정 함수 변경

기존에 만들었던 함수는 setIcon, setRightClick 2개로 분리해서 사용했는데, right icon이 있다면 right click 이벤트도 존재할 것이라 생각하여 두 함수를 묶어 setRightIcon 함수로 변경했습니다.

해당 함수 사용법은 아래와 같습니다.

```tsx
const Example = () => {
  const { setRightIcon } = useTopBarStore(); // 가져오기~~
  // ...
  useEffect(() => {
    setRightIcon(ExampleIcon, handleExampleClick); // 사용법~~~!
  }, []);
  // ...
}
```

### 앗!! placeholder 추가!!!!!

PR 작성하다가 생각난 placeholder를 추가했습니다.

```tsx
setSearchBar(searchTerm, setSearchTerm, "검색어를 입력해주세요."); // 이렇게 사용합니다~~!
```

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

![image](https://github.com/user-attachments/assets/0a76d520-baef-41d7-89eb-be6fd37256fa)
![image](https://github.com/user-attachments/assets/cb56e133-b960-46bf-ae1c-9d20318f8a24)

