### PR TITLE
feat: BlockedUsersTemplate 컴포넌트 개발

### DIFF
--- a/src/components/organisms/BlockedUserItem/index.tsx
+++ b/src/components/organisms/BlockedUserItem/index.tsx
@@ -1,17 +1,8 @@
 import { TextButton } from "components/atoms";
 import { Profile } from "../Profile";
 import { BlockedUserItemWrapper } from "./styled";
+import type { IProfile } from "types";
 
-export interface IProfile {
-  /** 프로필 이미지 URL */
-  imgUrl: string;
-  /** 닉네임 */
-  nickname: string;
-  /** 인증한 지역 */
-  location: string;
-  /** 차단 여부 */
-  isBlocked: boolean;
-}
 interface IBlockedUserItemWrapperProps {
   /** 유저 프로필 */
   profile: IProfile;

--- a/src/components/organisms/BlockedUsersList/index.tsx
+++ b/src/components/organisms/BlockedUsersList/index.tsx
@@ -1,14 +1,10 @@
-import { IProfile, BlockedUserItem } from "../BlockedUserItem";
+import { BlockedUserItem } from "../BlockedUserItem";
 import { BlockedUsersListWrapper } from "./styled";
+import type { IBlockedUserItem } from "types";
 
 interface IBlockedUsersListProps {
   /** BlockedUserItem 리스트 */
   blockedUserItems: IBlockedUserItem[];
-}
-
-export interface IBlockedUserItem {
-  profile: IProfile;
-  onClick: () => void;
 }
 
 export const BlockedUsersList = ({
@@ -21,7 +17,7 @@ export const BlockedUsersList = ({
           <BlockedUserItem
             key={idx}
             profile={blockedUserItem.profile}
-            onClick={blockedUserItem.onClick}
+            onClick={() => blockedUserItem.onClick(idx)}
           ></BlockedUserItem>
         );
       })}

--- a/src/components/organisms/BlockedUsersList/stories.ts
+++ b/src/components/organisms/BlockedUsersList/stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { BlockedUsersList, IBlockedUserItem } from ".";
-import { IProfile } from "../BlockedUserItem";
+import { BlockedUsersList } from ".";
+import type { IProfile, IBlockedUserItem } from "types";
 
 const meta: Meta<typeof BlockedUsersList> = {
   title: "Organisms/BlockedUsersList",

--- a/src/components/organisms/BlockedUsersList/styled.ts
+++ b/src/components/organisms/BlockedUsersList/styled.ts
@@ -3,6 +3,7 @@ import styled from "@emotion/styled";
 export const BlockedUsersListWrapper: ReturnType<
   typeof styled.div
 > = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 16px;

--- a/src/components/templates/BlockedUsersTemplate/index.tsx
+++ b/src/components/templates/BlockedUsersTemplate/index.tsx
@@ -1,0 +1,20 @@
+import {} from "components/atoms";
+import {} from "components/molecules";
+import { BlockedUsersList } from "components/organisms";
+import { BlockedUsersTemplateWrapper } from "./styled";
+import type { IBlockedUserItem } from "types";
+
+interface IBlockedUsersTemplateProps {
+  /** BlockedUserItem 리스트 */
+  blockedUserItems: IBlockedUserItem[];
+}
+
+export const BlockedUsersTemplate = ({
+  blockedUserItems
+}: IBlockedUsersTemplateProps) => {
+  return (
+    <BlockedUsersTemplateWrapper>
+      <BlockedUsersList blockedUserItems={blockedUserItems} />
+    </BlockedUsersTemplateWrapper>
+  );
+};

--- a/src/components/templates/BlockedUsersTemplate/stories.tsx
+++ b/src/components/templates/BlockedUsersTemplate/stories.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { BlockedUsersTemplate } from ".";
+import type { IProfile, IBlockedUserItem } from "types";
+
+const meta: Meta<typeof BlockedUsersTemplate> = {
+  title: "Templates/BlockedUsersTemplate",
+  component: BlockedUsersTemplate,
+  tags: ["autodocs"]
+};
+
+type Story = StoryObj<typeof meta>;
+
+/** 공통 프로필 생성 함수 */
+const createProfile = (
+  isBlocked: boolean,
+  nickname = "11시27분",
+  location = "망원동"
+): IProfile => ({
+  imgUrl: "https://github.com/ppyom.png",
+  nickname,
+  location,
+  isBlocked
+});
+
+/**  공통 유저 아이템 생성 함수 */
+const createUserItem = (isBlocked: boolean): IBlockedUserItem => ({
+  profile: createProfile(isBlocked),
+  onClick: () => {}
+});
+
+/**  공통 유저 리스트 생성 함수 */
+const createUserItems = (isBlocked: boolean) =>
+  Array(3)
+    .fill(null)
+    .map(() => createUserItem(isBlocked)); // 3개 생성
+
+const BlockedUsersTemplateWithState = () => {
+  const [blockedUserItems, setBlockedUserItems] = useState(
+    createUserItems(true)
+  );
+
+  const toggleBlockStatus = (index: number) => {
+    setBlockedUserItems((prevItems) =>
+      prevItems.map((item, i) =>
+        i === index
+          ? {
+              ...item,
+              profile: {
+                ...item.profile,
+                isBlocked: !item.profile.isBlocked
+              }
+            }
+          : item
+      )
+    );
+  };
+
+  const itemsWithHandlers = blockedUserItems.map((item, index) => ({
+    ...item,
+    onClick: () => toggleBlockStatus(index) // onClick 핸들러 설정
+  }));
+
+  return <BlockedUsersTemplate blockedUserItems={itemsWithHandlers} />;
+};
+export const Default: Story = {
+  render: () => <BlockedUsersTemplateWithState />
+};
+
+export default meta;

--- a/src/components/templates/BlockedUsersTemplate/styled.ts
+++ b/src/components/templates/BlockedUsersTemplate/styled.ts
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+
+export const BlockedUsersTemplateWrapper: ReturnType<
+  typeof styled.div
+> = styled.div`
+  display: flex;
+`;
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export * from "./map";
 export * from "./menu";
 export * from "./navMenu";
 export * from "./notification";
+export * from "./profile";
 export * from "./post";
 export * from "./response";
 export * from "./selectOption";

--- a/src/types/profile.d.ts
+++ b/src/types/profile.d.ts
@@ -1,0 +1,17 @@
+export interface IProfile {
+  /** 프로필 이미지 URL */
+  imgUrl: string;
+  /** 닉네임 */
+  nickname: string;
+  /** 인증한 지역 */
+  location: string;
+  /** 차단 여부 */
+  isBlocked: boolean;
+}
+export interface IBlockedUserItem {
+  /** 유저 프로필 */
+  profile: IProfile;
+  /** 차단하기 버튼 클릭시 동작 */
+  onClick: (index: number) => void;
+}
+


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #182

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->
- BlockedUsersTemplate 컴포넌트 개발

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->
- 컴포넌트 내의 type을 파일로 분리하고, IBlockedUserItem onClick 타입을 `(index: number) => void;`로 수정했습니다.
- 보니까 템플릿과 페이지가 props를 그대로 받아오는 경우가 많아서, 나중에 따로 type으로 분리해야 할 것 같습니다. 어떻게 분리할지는 생각을 해봐야 할 것 같습니다. (템플릿 interface만 template.d.ts로 뺀다던지..?, 아니면 각 비슷한 주제의 파일에 끼워넣기?)

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
![Templates _ BlockedUsersTemplate - Default ⋅ Storybook - Chrome 2024-12-03 09-41-05](https://github.com/user-attachments/assets/a53da5a9-27fa-445b-a835-5a07e98c172a)

