### PR TITLE
feat: 로그인 / 프로필 등록 백엔드 연동

### DIFF
--- a/src/pages/OAuthCallbackPage.tsx
+++ b/src/pages/OAuthCallbackPage.tsx
@@ -3,20 +3,11 @@ import {
   Navigate,
   useNavigate,
   useParams,
-  useSearchParams
+  useSearchParams,
 } from "react-router-dom";
 import { oauthLogin } from "services/apis";
 import { useUserStore } from "stores";
 import type { OAuthProvider } from "types";
-
-// 임시
-const response = {
-  result: {
-    nickname: undefined,
-    profile: undefined,
-    anything: "123123"
-  }
-} as const;
 
 export const OAuthCallbackPage = () => {
   // TODO 직접 접근 막기
@@ -31,18 +22,28 @@ export const OAuthCallbackPage = () => {
     if (code) {
       oauthLogin({ code, provider: provider!.toUpperCase() as OAuthProvider })
         .then((data) => {
-          // TODO result 확정 이후 수정 필요
-          console.log(data);
-          // const { result } = data;
-          const { result } = response;
-          setUser({ ...result });
+          const { result } = data;
 
           /**
            * TODO: 지금 따로 스토어를 만들었는데, user랑 합칠 지 논의 필요
            * 임시로 필요한 로직을 추가
            */
           // setActivityArea(result.activityAreaId, result.activityArea);
-          navigate(!result.nickname ? "/profile" : "/", { replace: true });
+
+          setUser({
+            profile: result.profileUrl || undefined,
+            nickname: result.nickname || undefined,
+            location: result.activityAreaId || undefined,
+          });
+
+          navigate(
+            !result.nickname
+              ? "/profile"
+              : !result.activityAreaId
+                ? "/neighborhood-selection"
+                : "/",
+            { replace: true },
+          );
         })
         .catch(console.error);
     }

--- a/src/pages/OAuthCallbackPage.tsx
+++ b/src/pages/OAuthCallbackPage.tsx
@@ -33,13 +33,14 @@ export const OAuthCallbackPage = () => {
           setUser({
             profile: result.profileUrl || undefined,
             nickname: result.nickname || undefined,
-            location: result.activityAreaId || undefined,
+            emdId: result.emdId || undefined,
+            emdName: result.emdName || undefined,
           });
 
           navigate(
             !result.nickname
               ? "/profile"
-              : !result.activityAreaId
+              : !result.emdName
                 ? "/neighborhood-selection"
                 : "/",
             { replace: true },

--- a/src/pages/ProfileRegistrationPage.tsx
+++ b/src/pages/ProfileRegistrationPage.tsx
@@ -2,37 +2,37 @@ import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { ProfileRegistrationTemplate } from "components/templates";
 import { useTopBarStore, useUserStore } from "stores";
-import { editProfile, registerProfile } from "services/apis";
+import { registerAndEditProfile } from "services/apis";
 import type { IUser, IUserProfileData } from "types";
 
 export const ProfileRegistrationPage = () => {
   const navigate = useNavigate();
   const { user } = useUserStore();
-  const { setTitle } = useTopBarStore();
+  const { clear, setTitle } = useTopBarStore();
 
   const handleProfileRegistration = (data: IUser) => {
     console.log(user);
     console.log(data);
-    // 닉네임 등록 상태로 첫 번째 로그인(프로필 등록 안한 사용자)인지 구분
-    const isFirstLogin = !user?.nickname;
     // nickname은 검사하고 오기 때문에 타입 어설션 사용
     const nickname = data.nickname!;
     const profile = data.profile;
-    const requestData: IUserProfileData = { nickname };
+    const requestData: IUserProfileData = {
+      name: nickname,
+    };
 
     if (typeof profile !== "string") {
-      // profile이 이미 있던 프로필이 아니라면 requestData에 담기!
-      requestData.profile = profile;
+      requestData.image = profile || null;
     }
 
     // TODO API 확정 이후 수정
-    (isFirstLogin ? registerProfile : editProfile)(requestData)
+    registerAndEditProfile(requestData)
       .then((data) => {
         console.log(data);
         // 저장 완료 내역을 클라이언트에도 적용
         // const { result } = data;
         // setUser(result);
-        navigate(isFirstLogin ? "/neighborhood-selection" : "/my-page", {
+
+        navigate(!user?.emdId ? "/neighborhood-selection" : "/my-page", {
           replace: true,
         });
       })
@@ -43,12 +43,13 @@ export const ProfileRegistrationPage = () => {
   };
 
   useEffect(() => {
+    clear();
     setTitle("프로필 등록");
   }, []);
 
   return (
     <ProfileRegistrationTemplate
-      user={user}
+      user={user || undefined}
       onSubmit={handleProfileRegistration}
     />
   );

--- a/src/services/apis/user.ts
+++ b/src/services/apis/user.ts
@@ -2,44 +2,26 @@ import { http } from "services/api";
 import type { IUserProfileData, IUserProfileResponse } from "types";
 
 /**
- * 유저 프로필 등록
- * @param nickname
- * @param profile
+ * 유저 프로필 등록 / 수정
+ * @param name 유저가 입력한 닉네임
+ * @param image 유저의 프로필사진
  */
-export const registerProfile = async ({
-  nickname,
-  profile,
+export const registerAndEditProfile = async ({
+  name,
+  image,
 }: IUserProfileData) => {
-  return http.post<IUserProfileResponse, IUserProfileData>(
-    "/user/profile",
-    {
-      nickname,
-      profile,
-    },
-    {
-      headers: {
-        "Content-Type": "multipart/form-data",
-      },
-    },
-  );
-};
+  const formData = new FormData();
 
-/**
- * 유저 프로필 수정
- * @param nickname
- * @param profile
- */
-export const editProfile = async ({ nickname, profile }: IUserProfileData) => {
-  return http.patch<IUserProfileResponse, IUserProfileData>(
-    "/user/profile",
-    {
-      nickname,
-      profile,
+  formData.append("request", JSON.stringify(name));
+  if (image) {
+    formData.append("image", image);
+  }
+  console.log(formData);
+  console.log(Array.from(formData.keys()));
+
+  return http.post<IUserProfileResponse, FormData>("/users/profile", formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
     },
-    {
-      headers: {
-        "Content-Type": "multipart/form-data",
-      },
-    },
-  );
+  });
 };

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -5,14 +5,14 @@ import type { IUser } from "types";
 const localStorageKey = "meerket--login" as const;
 
 interface UserState {
-  user?: IUser;
+  user: IUser | null; // @rushstack/ no-new-null
   setUser: (user: IUser) => void;
 }
 
 export const useUserStore: UseBoundStore<StoreApi<UserState>> = create(
   persist<UserState>(
     (set) => ({
-      user: undefined,
+      user: null,
       setUser: (user) => set({ user }),
     }),
     {

--- a/src/types/response/auth.d.ts
+++ b/src/types/response/auth.d.ts
@@ -2,9 +2,14 @@ import type { IResponse } from "types";
 
 export type OAuthProvider = "NAVER" | "KAKAO";
 
+export interface IAuth {
+  nickname: string | null;
+  profileUrl: string | null;
+  activityAreaId: number | null;
+}
+
 export interface IAuthResponse extends IResponse {
-  // TODO result 확정 이후 수정 필요
-  result: {};
+  result: IAuth;
 }
 
 export interface IAuthData {

--- a/src/types/response/auth.d.ts
+++ b/src/types/response/auth.d.ts
@@ -5,7 +5,8 @@ export type OAuthProvider = "NAVER" | "KAKAO";
 export interface IAuth {
   nickname: string | null;
   profileUrl: string | null;
-  activityAreaId: number | null;
+  emdId: number | null;
+  emdName: string | null;
 }
 
 export interface IAuthResponse extends IResponse {

--- a/src/types/response/user.d.ts
+++ b/src/types/response/user.d.ts
@@ -11,6 +11,6 @@ export interface IUserProfileResponse extends IResponse {
  * Profile 등록 / 수정 Request Body
  */
 export interface IUserProfileData {
-  nickname: string | null;
-  profile: File | string | null;
+  name: string | null;
+  image?: File | string | null;
 }

--- a/src/types/response/user.d.ts
+++ b/src/types/response/user.d.ts
@@ -11,6 +11,6 @@ export interface IUserProfileResponse extends IResponse {
  * Profile 등록 / 수정 Request Body
  */
 export interface IUserProfileData {
-  nickname: string;
-  profile?: File | string;
+  nickname: string | null;
+  profile: File | string | null;
 }

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -2,4 +2,5 @@ export interface IUser {
   id?: number;
   nickname?: string;
   profile?: string | File;
+  location?: number;
 }

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -2,5 +2,6 @@ export interface IUser {
   id?: number;
   nickname?: string;
   profile?: string | File;
-  location?: number;
+  emdId?: number;
+  emdName?: string;
 }


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #262

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->

로그인 백엔드 연동했습니다.

로그인 시 nickname, profileImage, 선택한 동네 정보가 넘어오는데 해당 정보를 zustand를 통해 저장하도록 설정했습니다.

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->

- 프로필 등록은 API 확인 후 다시 올리겠습니다.

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
