### PR TITLE
fix: 디자인 어색한부분 수정

### DIFF
--- a/src/components/organisms/Modal/styled.ts
+++ b/src/components/organisms/Modal/styled.ts
@@ -69,9 +69,8 @@ export const ModalRootWrapper: ReturnType<
   left: 50%;
   translate: -50%;
   z-index: 9999;
-  max-width: 400px;
-  // max-width: 375px;
-  width: calc(100% - 2rem);
+  max-width: ${({ theme }) => theme.sizes.max_width};
+  width: 100%;
   height: 100%;
   // 자식 요소 배치
   display: flex;

--- a/src/components/organisms/TopBar/styled.ts
+++ b/src/components/organisms/TopBar/styled.ts
@@ -6,10 +6,10 @@ import { IconButtonWrapper } from "components/atoms/Button/IconButton/styled";
 
 const CommonIconWrapper: ReturnType<typeof styled.div> = styled.div``;
 export const TopBarBackIconWrapper: typeof CommonIconWrapper = styled(
-  CommonIconWrapper
+  CommonIconWrapper,
 )``;
 export const TopBarIconWrapper: typeof CommonIconWrapper = styled(
-  CommonIconWrapper
+  CommonIconWrapper,
 )`
   ${IconButtonWrapper}:has(${NoIconWrapper}) {
     cursor: default;
@@ -29,11 +29,15 @@ export const TopBarWrapper: ReturnType<typeof styled.div> = styled.div`
     flex: 1;
     padding: 0.5rem;
     text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   & > ${InputWrapper} {
     flex: 1;
-    height: 19/16rem;
-    padding: 15.5/16rem 1rem;
+    // 적용 안되고있는 속성이라 주석처리했습니다!
+    // height: 19/16rem;
+    // padding: 15.5/16rem 1rem;
     background-color: #eee;
   }
   &:has(${InputWrapper}) ${TopBarIconWrapper} {


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #321

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->

- TopBar 제목이 길어졌을 때 1줄만 나오도록 수정했습니다.
- 모달 배경이 모바일 사이즈로 작아졌을 때 비어보이던 현상을 수정했습니다.

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->

- PostItem의 경우 수정하려고 확인해보니 대공사가 될 것 같아 수정하지 않았습니다.

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/484bd37c-2d3b-4aae-94e9-d5624c76b2d3) | ![image](https://github.com/user-attachments/assets/101f0e66-5cbd-4941-87d4-18d05dac3eb0) |
| ![image](https://github.com/user-attachments/assets/8547ce2f-6971-4c32-94de-97ca46d0dff0) | ![image](https://github.com/user-attachments/assets/b0ea5da0-c848-4eef-91fd-b255e2107f4c) |



