### PR TITLE
feat: 구매내역 API 연동 (1차)

### DIFF
--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -4,6 +4,10 @@ const COMMENT = "comment" as const;
 const AUCTION = "auction" as const;
 const PURCHASES = "purchases" as const;
 const BIDDING = "bidding" as const;
+const TRANSACTION = "transaction" as const;
+const SELL = "sell" as const;
+const IN_PROGRESS = "in_progress" as const;
+const COMPLETED = "completed" as const;
 
 export const queries = {
   session: {
@@ -20,5 +24,13 @@ export const queries = {
     DEFAULT: [AUCTION],
     purchases: [AUCTION, PURCHASES],
     bidding: [AUCTION, BIDDING],
+  },
+  transaction: {
+    DEFAULT: [TRANSACTION],
+    sell: {
+      DEFAULT: [TRANSACTION, SELL],
+      in_progress: [TRANSACTION, SELL, IN_PROGRESS],
+      completed: [TRANSACTION, SELL, COMPLETED],
+    },
   },
 } as const;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -18,3 +18,4 @@ export * from "./useFetchComment";
 export * from "./useFetchBidding";
 export * from "./useModalForm";
 export * from "./useFetchSession";
+export * from "./useFetchTransactions";

--- a/src/hooks/useFetchTransactions.ts
+++ b/src/hooks/useFetchTransactions.ts
@@ -1,0 +1,78 @@
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+import { queries } from "constants/queryKeys";
+import {
+  getBidding,
+  getCompletedProducts,
+  getInProgressProducts,
+} from "services/apis";
+import type {
+  IAuction,
+  IGetBiddingResponse,
+  ITransactionProduct,
+  ITransactionResponse,
+} from "types";
+
+export type TransactionType = "buy" | "sell";
+export type TransactionTab = "in_progress" | "completed";
+
+/**
+ * ReactQuery 요청 시 사용할 key와 function을 가져올 때 사용할 함수
+ * @param type 현재 페이지 타입
+ * @param tab 현재 선택되어있는 탭
+ */
+const getQuery = (
+  type: TransactionType,
+  tab: TransactionTab,
+  // TODO IGetBiddingResponse쪽에 해당 함수 Response Type 넣어주세요!!
+): UseQueryOptions<ITransactionResponse | IGetBiddingResponse> => {
+  if (type === "sell") {
+    // 판매자 입장
+    if (tab === "in_progress") {
+      // 판매중
+      return {
+        queryKey: queries.transaction.sell.in_progress,
+        queryFn: () => getInProgressProducts(),
+      };
+    } else {
+      // 판매 완료
+      return {
+        queryKey: queries.transaction.sell.completed,
+        queryFn: () => getCompletedProducts(),
+      };
+    }
+  } else {
+    // TODO 구매자 입장
+    if (tab === "in_progress") {
+      // 구매중
+      return {
+        queryKey: queries.auction.bidding,
+        queryFn: () => getBidding(),
+      };
+    } else {
+      // 구매 완료
+      return {
+        queryKey: queries.auction.purchases,
+        queryFn: () => getBidding(),
+      };
+    }
+  }
+};
+
+export const useFetchTransactions = (
+  type: TransactionType,
+  tab: TransactionTab,
+) => {
+  // TODO 이후 useInfinityQuery로 변경해서 무한스크롤 구현?? ㅠ..
+  const { data, isLoading } = useQuery({
+    ...getQuery(type, tab),
+    select: (data) =>
+      "content" in data.result
+        ? (data.result.content as ITransactionProduct[])
+        : (data.result as IAuction[]),
+  });
+
+  return {
+    products: data || null,
+    isLoading,
+  };
+};

--- a/src/services/apis/index.ts
+++ b/src/services/apis/index.ts
@@ -5,3 +5,4 @@ export * from "./comment";
 export * from "./activityAreas";
 export * from "./auction";
 export * from "./areaAuth";
+export * from "./transaction";

--- a/src/services/apis/transaction.ts
+++ b/src/services/apis/transaction.ts
@@ -1,0 +1,36 @@
+import { http } from "services/api";
+import type { ITransactionQueryParams, ITransactionResponse } from "types";
+
+const SIZE = 30 as const;
+
+/**
+ * 내가 판매중인 상품 목록을 가져오는 함수
+ */
+export const getInProgressProducts = async () =>
+  // cursor: ITransactionQueryParams["cursor"] = 1,
+  {
+    return http.get<ITransactionResponse, ITransactionQueryParams>(
+      `/products/my`,
+      {
+        // cursor,
+        size: SIZE,
+        status: "IN_PROGRESS",
+      },
+    );
+  };
+
+/**
+ * 내 판매 완료 상품 목록을 가져오는 함수
+ */
+export const getCompletedProducts = async () =>
+  // cursor: ITransactionQueryParams["cursor"] = 1,
+  {
+    return http.get<ITransactionResponse, ITransactionQueryParams>(
+      `/products/my`,
+      {
+        // cursor,
+        size: SIZE,
+        status: "COMPLETED",
+      },
+    );
+  };

--- a/src/types/response/index.ts
+++ b/src/types/response/index.ts
@@ -7,3 +7,4 @@ export * from "./comment";
 export * from "./activityAreas";
 export * from "./auction";
 export * from "./areaAuth";
+export * from "./transaction";

--- a/src/types/response/transaction.d.ts
+++ b/src/types/response/transaction.d.ts
@@ -1,0 +1,32 @@
+import type { IResponse } from "types";
+
+export type TransactionStatus =
+  | "BIDDING"
+  | "IN_PROGRESS"
+  | "COMPLETED"
+  | "DELETED";
+
+export interface ITransactionProduct {
+  productIdL: number;
+  title: string;
+  imageUrl: string;
+  productAddress: string;
+  createdAt: string;
+  price: number;
+  expiredTime: string;
+  winningPrice: number;
+  status: TransactionStatus;
+}
+
+export interface ITransactionResponse extends IResponse {
+  result: {
+    content: ITransactionProduct[];
+    nextCursor: number;
+  };
+}
+
+export interface ITransactionQueryParams {
+  size: number;
+  // cursor: number;
+  status: TransactionStatus;
+}


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #347

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->

구매내역 API 연동했습니다.

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->

- 현재 API가 제대로 동작하는지는 확인중입니다.
- Empty Template를 일단!! 적용하지 않았습니다. (조금 더 확인해보고 적용)
- 판매내역쪽에서 `Warning: Encountered two children with the same key, '-1'.`가 발생하는데 백엔드에서 보내주는 데이터에 productId가 없어서 발생하는 오류입니다. 이후 productId가 추가되면 수정이 필요하지 않고, 추가되지 않는다면 index를 넘겨서 처리하도록 수정하겠습니다.
- 남은시간 over도 이후 수정하겠습니다.

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

![image](https://github.com/user-attachments/assets/ceb82a6b-2f40-4e93-8467-6f8fc7767713)
![image](https://github.com/user-attachments/assets/a5659b3c-b773-4775-b2f9-0898aeb907fa)

