### PR TITLE
feat: 거래 완료 api 연동

### DIFF
--- a/src/pages/ChatRoomPage.tsx
+++ b/src/pages/ChatRoomPage.tsx
@@ -1,16 +1,17 @@
 import { Loading } from "components/molecules/Loading";
 import { IPost } from "components/organisms/PostList";
+import { Toast } from "components/atoms";
 import { EmptyTemplate } from "components/templates";
 import { ChatRoomTemplate } from "components/templates/ChatRoomTemplate";
 import { TopSheet } from "components/templates/ChatRoomTemplate/TopSheet";
 import { DEFAULT_IMG_PATH } from "constants/imgPath";
-import { useModalForm } from "hooks";
 import { useChatGroups } from "hooks/useChatGroups";
 import { useWebSocket } from "hooks/useWebSocket";
 import { throttle } from "lodash";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { http } from "services/api";
+import { completeProduct } from "services/apis";
 import { useTopBarStore } from "stores";
 import { IResponse } from "types";
 import { decryptRoomId } from "utils/security";
@@ -60,7 +61,6 @@ interface IChatRoomNewMsgResponse extends IResponse {
 }
 export const ChatRoomPage = () => {
   const { clear, setTitle } = useTopBarStore();
-  const { todo } = useModalForm();
   const navigate = useNavigate();
   const { roomId, userId } = useParams(); // URL에서 roomId 가져오기
   const decrtyptRoomId = roomId ? decryptRoomId(roomId) : "";
@@ -101,7 +101,15 @@ export const ChatRoomPage = () => {
       navigate(`/product/${chatRoomBasicInfo.productId}`);
     },
     onTextButtonClick: () => {
-      todo();
+      completeProduct(chatRoomBasicInfo.productId!.toString())
+              .then((data) => {
+                console.log(data);
+                Toast.show("거래가 완료되었어요!", 2000);
+              })
+              .catch((error) => {
+                Toast.show("잠시 후에 다시 시도해 주세요.", 2000);
+                console.error(error);
+              });
     },
     onIconButtonClick: () => {
       console.log("onIconButtonClick");

--- a/src/services/apis/product.ts
+++ b/src/services/apis/product.ts
@@ -105,3 +105,11 @@ export const editProduct = async (
 export const deleteProduct = async (productId: string) => {
   return http.delete<IProductResponse>(`/products/${productId}`);
 };
+
+/**
+ * 중고 제품 게시글 거래 완료하기기
+ * @param productId 거래 완료 제품 id
+ */
+export const completeProduct = async (productId: string) => {
+  return http.patch<IProductResponse>(`/products/${productId}/complete`);
+};


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #351

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->
- 거래 완료 api 연동

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->
- api만 연동하였기 때문에 아래와 같은 작업이 추가로 필요합니다.
  1. 거래 완료를 누를 시 버튼이 `disabled`로 바뀌며 '거래 완료'가 아닌 다른 안내 text로 바뀌도록 수정하기 (`PostList` 수정 필요)
  2. 백엔드에서 채팅하는 물품의 거래 완료 여부 상태를 추가로 받아오기 (백엔드와 api 논의 필요) 
 - 뮤테이션을 적용하려 했는데, 게시글 등록 form에 먼저 적용해보고, 추후에 다른 곳에도 적용해 놓겠습니다..! 

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
