### PR TITLE
feat: 판매내역 API 연동 (2차)

### DIFF
--- a/src/components/organisms/PostItem/index.tsx
+++ b/src/components/organisms/PostItem/index.tsx
@@ -170,7 +170,10 @@ const PostItemRemainingTime = ({
     <PostItemRemainingTimeWrapper>
       <Text variant="tag_regular" content="남은 시간" />
       <Text variant="tag_regular" content="·" />
-      <Text variant="tag_regular" content={timeRemaining} />
+      <Text
+        variant="tag_regular"
+        content={timeRemaining === "over" ? "종료" : timeRemaining}
+      />
     </PostItemRemainingTimeWrapper>
   );
 };

--- a/src/pages/TransactionPage.tsx
+++ b/src/pages/TransactionPage.tsx
@@ -28,17 +28,19 @@ export const TransactionPage = ({ type }: TransactionPageProps) => {
   /**
    * 백엔드 ResponseData를 IPost Item에 들어갈 형식으로 변환하는 함수
    * @param post ResponseData로 넘어온 post
+   * @param index
    * @returns IPost
    */
   const createTransactionPostItem = (
     post: IAuction | ITransactionProduct,
+    index: number,
   ): IPost => {
     const product: Omit<
       IPost,
       "onClick" | "onTextButtonClick" | "onIconButtonClick"
     > = {
       /** 게시글 ID */
-      productId: ("productId" in post && post.productId) || -1,
+      productId: ("productId" in post && post.productId) || index,
       /** 게시글 썸네일 이미지 */
       imgUrl:
         ("imageUrl" in post && post.imageUrl) ||
@@ -129,7 +131,9 @@ export const TransactionPage = ({ type }: TransactionPageProps) => {
       <TransactionTemplate
         onClick={onHandleTab}
         posts={
-          products?.map((product) => createTransactionPostItem(product)) || []
+          products?.map((product, idx) =>
+            createTransactionPostItem(product, idx),
+          ) || []
         }
       />
     </Suspense>


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #347

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->

- key 때문에 오류나던 부분 수정
- timeRemaining 값이 over일 때 종료로 보이도록 수정

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->

- empty template을 적용하기 위해서는 TransactionOverview부터 수정이 필요해 우선 보류했습니다.

- 판매중 => 글을 올렸지만 판매되지 않은(거래완료/삭제되지 않은) 내역
- 거래완료 => 글을 올리고 판매가 완료된(거래완료된) 내역

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

![image](https://github.com/user-attachments/assets/8daf1ff4-05b3-44c8-ae75-74bb8c19eaa8)
