### PR TITLE
feat: 20억 초과 입력 시 처리

### DIFF
--- a/src/components/organisms/AuctionBidBottomSheet/index.tsx
+++ b/src/components/organisms/AuctionBidBottomSheet/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Input, Text, TextButton } from "components/atoms";
 import type { IModalBottomSheetProps } from "components/molecules/ModalBottomSheet";
 
@@ -29,6 +29,10 @@ export const AuctionBidBottomSheet = ({
   const placeholder = beforePrice
     ? `내 입찰가 ${beforePrice.toLocaleString()}`
     : `최소 ${minPrice.toLocaleString()}`;
+  const isInvalidPrice = useMemo(
+    () => parseInt(price.replace(/,/g, "")) > 2000000000,
+    [price],
+  );
 
   return (
     <AuctionBidBottomSheetWrapper open={open} onClose={onClose}>
@@ -39,11 +43,19 @@ export const AuctionBidBottomSheet = ({
         setValue={setPrice}
         placeholder={placeholder}
       />
+      {isInvalidPrice && (
+        <div style={{ color: "#FF2E4D" }}>
+          <Text
+            variant="explan_regular"
+            content={"20억 이하로 입력해주세요."}
+          />
+        </div>
+      )}
       <Text
         variant="desc_regular"
         content={`최소 입찰가 ${minPrice.toLocaleString()}`}
       />
-      <TextButton text="입찰하기" onClick={onBid} />
+      <TextButton text="입찰하기" onClick={onBid} disabled={isInvalidPrice} />
     </AuctionBidBottomSheetWrapper>
   );
 };

--- a/src/components/organisms/AuctionBidBottomSheet/styled.ts
+++ b/src/components/organisms/AuctionBidBottomSheet/styled.ts
@@ -22,5 +22,10 @@ export const AuctionBidBottomSheetWrapper: StyledComponent<
   ${TextButtonWrapper} {
     margin: 0;
     background-color: ${({ theme }) => theme.colors.blue_text};
+    &:disabled {
+      cursor: default;
+      background-color: ${({ theme }) =>
+        theme.colors.grey_field_guide_but_deactivate};
+    }
   }
 `;

--- a/src/components/organisms/PostRegisterForm/index.tsx
+++ b/src/components/organisms/PostRegisterForm/index.tsx
@@ -177,6 +177,12 @@ export const PostRegisterForm = ({
         control={control}
         rules={{
           required: "최저 입찰가는 필수 입력 항목입니다.",
+          validate: {
+            checkValue: (value) =>
+              value &&
+              parseInt(value.replace(/,/g, "")) > 2000000000 &&
+              "20억 이하로 입력해주세요.",
+          },
         }}
         render={({ field: { value }, fieldState: { invalid }, formState }) => (
           <DivWrapper>


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #352

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->

20억 초과 입력 시 처리했습니다. (AuctionBidBottomSheet, PostRegisterForm)

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->

### AuctionBidBottomSheet

1. 현재 입력된 price가 20억 넘는지 확인
2. 20억 넘으면 버튼 disabled & 에러메시지 활성화

### PostRegisterForm

1. minimumPrice의 validate에 checkValue에서 20억 넘는지 확인
2. 20억 넘으면 error메시지에 (자동)추가

### 살짝 아쉬운 부분

AuctionBidBottomSheet에서 다른 입력값을 처리하는 부분들도 이후 다 이런식으로 처리하면 좋겠습니다~~!

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

![Image](https://github.com/user-attachments/assets/fb935e2a-3059-4aac-a9cc-c9b47bef4c39)

![Image](https://github.com/user-attachments/assets/9ea17570-9dd0-42e4-aee0-f722df6c0428)