### PR TITLE
feat: 신고하기 API 연동

### DIFF
--- a/src/components/organisms/Comment/index.tsx
+++ b/src/components/organisms/Comment/index.tsx
@@ -39,7 +39,7 @@ export const Comment = ({ comments, hasBuyer }: ICommentProps) => {
           (
             {
               commentId,
-              commentMemeberDto: { profileIamge, nickname },
+              commentMemeberDto: { profileIamge, nickname, userId },
               createdAt,
               content,
               replies,
@@ -47,7 +47,7 @@ export const Comment = ({ comments, hasBuyer }: ICommentProps) => {
               isSeller,
               status,
             },
-            idx,
+            idx
           ) => (
             <CommentItem
               key={`comment_${idx}_${commentId}`}
@@ -62,8 +62,9 @@ export const Comment = ({ comments, hasBuyer }: ICommentProps) => {
               status={status}
               isSeller={isSeller}
               hasBuyer={hasBuyer}
+              targetId={userId}
             />
-          ),
+          )
         )}
       </CommentListWrapper>
     </CommentWrapper>

--- a/src/components/organisms/CommentItem/index.tsx
+++ b/src/components/organisms/CommentItem/index.tsx
@@ -203,7 +203,7 @@ export const CommentItem = ({
                       {!isMyComment && (
                         <>
                           <KebabMenu.Button
-                            content="댓글 차단하기"
+                            content="유저 차단하기"
                             onClick={handleBlockClick}
                           />
                           <KebabMenu.Button

--- a/src/components/organisms/CommentItem/index.tsx
+++ b/src/components/organisms/CommentItem/index.tsx
@@ -3,8 +3,13 @@ import { KebabIcon, ReplyIcon } from "components/atoms/Icon";
 import { InputWithButton, KebabMenu } from "components/molecules";
 import { getRelativeTime } from "utils";
 import { useCommentWriter, useDetailModal, useKebabMenu } from "hooks";
-import { useUserStore } from "stores";
-import type { CommentStatus, IComment, IWriteCommentData } from "types";
+import { useModalStore, useUserStore } from "stores";
+import type {
+  CommentStatus,
+  IComment,
+  IWriteCommentData,
+  ReportType,
+} from "types";
 import { LOGO_PATH } from "constants/imgPath";
 import {
   CommentContentWrapper,
@@ -19,6 +24,7 @@ import {
   WriterBadgeWrapper,
 } from "./styled";
 import { DeletedComment } from "./deleted";
+import { reportUser } from "services/apis";
 
 export interface ICommentItemProps {
   /** 댓글 아이디 */
@@ -43,6 +49,8 @@ export interface ICommentItemProps {
   isSeller: boolean;
   /** 현재 구매자가 있는 상태인지 여부 */
   hasBuyer?: boolean;
+  /** 신고 대상 아이디 */
+  targetId?: number;
 }
 
 export const CommentItem = ({
@@ -57,6 +65,7 @@ export const CommentItem = ({
   status,
   isSeller,
   hasBuyer,
+  targetId,
 }: ICommentItemProps) => {
   const { user } = useUserStore();
   const { menuRef, open, handleOpen, handleClose } = useKebabMenu();
@@ -74,8 +83,10 @@ export const CommentItem = ({
     handleDeleteComment,
   } = useCommentWriter(content);
   const time = getRelativeTime(createdAt);
-  const { todo } = useDetailModal();
-
+  const { todo, reportComment, reportComplete } = useDetailModal();
+  const {
+    actions: { closeModal },
+  } = useModalStore();
   /**
    * 답글 메뉴 클릭
    */
@@ -123,8 +134,24 @@ export const CommentItem = ({
    * 신고하기 메뉴 클릭
    */
   const handleReportClick = () => {
-    // TODO 신고하기
-    todo();
+    reportComment(() => {
+      if (targetId) {
+        const requestData = {
+          title: "댓글 신고",
+          content: content,
+          reportType: "COMMENT" as ReportType,
+          targetId: targetId,
+        };
+        reportUser(requestData)
+          .then(() => {
+            reportComplete();
+          })
+          .catch(() => {
+            console.error();
+            closeModal();
+          });
+      }
+    });
     handleClose();
   };
 
@@ -176,11 +203,11 @@ export const CommentItem = ({
                       {!isMyComment && (
                         <>
                           <KebabMenu.Button
-                            content="차단하기"
+                            content="댓글 차단하기"
                             onClick={handleBlockClick}
                           />
                           <KebabMenu.Button
-                            content="신고하기"
+                            content="유저 신고하기"
                             onClick={handleReportClick}
                           />
                         </>
@@ -221,7 +248,7 @@ export const CommentItem = ({
                     isSeller,
                     status,
                   },
-                  idx,
+                  idx
                 ) => (
                   <ReplyCommentWrapper key={`comment_${idx}_${childId}`}>
                     <ReplyIcon />
@@ -239,7 +266,7 @@ export const CommentItem = ({
                       hasBuyer={hasBuyer}
                     />
                   </ReplyCommentWrapper>
-                ),
+                )
               )}
             </ReplyCommentContainer>
           )}

--- a/src/components/organisms/PostItem/index.tsx
+++ b/src/components/organisms/PostItem/index.tsx
@@ -86,7 +86,11 @@ interface IPostItemTitleProps {
  * @param title 제목
  */
 const PostItemTitle = ({ title }: IPostItemTitleProps) => {
-  return <PostItemTitleWrapper><Text variant="title_bold" content={title} /></PostItemTitleWrapper>;
+  return (
+    <PostItemTitleWrapper>
+      <Text variant="title_bold" content={title} />
+    </PostItemTitleWrapper>
+  );
 };
 
 /* -------------------------------------------------------------------
@@ -113,7 +117,6 @@ const PostItemLocationAndTime = ({
     type === "default"
       ? getRelativeTime(uploadTime)
       : formatToDateTime(uploadTime);
-  console.log("time : ", uploadTime);
   return (
     <PostItemLocationAndTimeWrapper>
       <Text variant="tag_regular" content={address} />
@@ -201,7 +204,7 @@ interface IPostItemButtonContainerProps {
 const PostItemButtonContainer = ({
   buttonText,
   onTextButtonClick,
-  disabled
+  disabled,
 }: //icon,
 //onIconButtonClick,
 IPostItemButtonContainerProps) => {
@@ -210,7 +213,11 @@ IPostItemButtonContainerProps) => {
   };
   return (
     <PostItemButtonContainerWrapper onClick={handleStopPropagation}>
-      <TextButton text={buttonText} onClick={onTextButtonClick} disabled={disabled} />
+      <TextButton
+        text={buttonText}
+        onClick={onTextButtonClick}
+        disabled={disabled}
+      />
 
       {/* 채팅방 물품 정보 오른쪽 아이콘 버튼 임시 삭제(디자인시안에 존재 X) 
       {icon && <IconButton size="m" icon={icon} onClick={onIconButtonClick} />} */}

--- a/src/constants/modalMessage.ts
+++ b/src/constants/modalMessage.ts
@@ -35,5 +35,18 @@ export const modalMessage = {
           "잘 확인해주세요",
       },
     },
+    comment: {
+      report: {
+        DEFAULT: "해당 댓글을 작성한 사용자를 신고하시겠습니까?",
+      },
+    },
+    post: {
+      report: {
+        DEFAULT: "해당 게시글을 작성한 사용자를 신고하시겠습니까?",
+      },
+    },
+    report: {
+      COMPLETE: "신고가 접수되었습니다.",
+    },
   },
 } as const;

--- a/src/hooks/useDetailModal.ts
+++ b/src/hooks/useDetailModal.ts
@@ -20,9 +20,16 @@ export const useDetailModal = () => {
   const removeHasBuyer = (onRemove: () => void) =>
     confirm(modalMessage.product.seller.remove.hasBuyer, onRemove);
 
-  // 차단 / 신고
+  // 차단
   const todo = todoModal;
-
+  // 댓글 신고하기
+  const reportComment = (onReportComment: () => void) =>
+    confirm(modalMessage.product.comment.report.DEFAULT, onReportComment);
+  // 게시글 신고하기
+  const reportPost = (onReportPost: () => void) =>
+    confirm(modalMessage.product.post.report.DEFAULT, onReportPost);
+  // 신고 완료
+  const reportComplete = () => alert(modalMessage.product.report.COMPLETE);
   return {
     cancel,
     cancelEarly,
@@ -32,5 +39,8 @@ export const useDetailModal = () => {
     removeNoBuyer,
     removeHasBuyer,
     todo,
+    reportComment,
+    reportPost,
+    reportComplete,
   };
 };

--- a/src/pages/DetailPage/index.tsx
+++ b/src/pages/DetailPage/index.tsx
@@ -249,11 +249,11 @@ export const DetailPage = () => {
             {!product.isSeller && (
               <>
                 <KebabMenu.Button
-                  content="작성자 차단하기"
+                  content="유저 차단하기"
                   onClick={handleBlock}
                 />
                 <KebabMenu.Button
-                  content="작성자 신고하기"
+                  content="유저 신고하기"
                   onClick={handleReport}
                 />
               </>

--- a/src/pages/DetailPage/index.tsx
+++ b/src/pages/DetailPage/index.tsx
@@ -18,8 +18,8 @@ import {
   useDetailModal,
 } from "hooks";
 import { KebabWrapper } from "./styled";
-import { deleteProduct, earlyClose } from "services/apis";
-import type { Category } from "types";
+import { deleteProduct, earlyClose, reportUser } from "services/apis";
+import type { Category, ReportType } from "types";
 import { Toast } from "components/atoms";
 import { isExpired } from "../../utils";
 
@@ -40,10 +40,11 @@ export const DetailPage = () => {
   const { setFormData, setProductId } = useFormDataStore();
   const { open, handleOpen, handleClose, menuRef } = useKebabMenu();
   const { handleCancel } = useBid(parseInt(productId!));
-  const { todo, removeNoBuyer, removeHasBuyer } = useDetailModal();
+  const { todo, removeNoBuyer, removeHasBuyer, reportPost, reportComplete } =
+    useDetailModal();
   const isExpiredTime = useMemo(
     () => !!product?.expiredTime && isExpired(product?.expiredTime),
-    [isProductRefetching],
+    [isProductRefetching]
   );
 
   /**
@@ -74,8 +75,24 @@ export const DetailPage = () => {
    * (구매자) 신고
    */
   const handleReport = () => {
-    // TODO 신고
-    todo();
+    reportPost(() => {
+      if (product) {
+        const requestData = {
+          title: product.title,
+          content: product.content,
+          reportType: "POST" as ReportType,
+          targetId: product.seller.id,
+        };
+        reportUser(requestData)
+          .then(() => {
+            reportComplete();
+          })
+          .catch(() => {
+            console.error();
+            closeModal();
+          });
+      }
+    });
     handleClose();
   };
 
@@ -175,7 +192,7 @@ export const DetailPage = () => {
   useEffect(() => {
     setRightIcon(
       KebabIcon,
-      isExpiredTime ? () => Toast.show("마감된 상품입니다.", 2000) : handleOpen,
+      isExpiredTime ? () => Toast.show("마감된 상품입니다.", 2000) : handleOpen
     );
     return () => {
       clear();
@@ -231,8 +248,14 @@ export const DetailPage = () => {
             )}
             {!product.isSeller && (
               <>
-                <KebabMenu.Button content="차단하기" onClick={handleBlock} />
-                <KebabMenu.Button content="신고하기" onClick={handleReport} />
+                <KebabMenu.Button
+                  content="작성자 차단하기"
+                  onClick={handleBlock}
+                />
+                <KebabMenu.Button
+                  content="작성자 신고하기"
+                  onClick={handleReport}
+                />
               </>
             )}
           </KebabMenu>

--- a/src/services/apis/user.ts
+++ b/src/services/apis/user.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import type {
+  IReportUser,
   ISessionUserResponse,
   IUserProfileData,
   IUserProfileResponse,
@@ -47,7 +48,52 @@ export const registerAndEditProfile = async ({
       formData,
       {
         withCredentials: true,
-      },
+      }
+    );
+    console.log("Response:", res.data); // 요청 성공 시 응답 데이터 출력
+    return res.data; // 요청 성공 시 응답 데이터 반환
+  } catch (error) {
+    console.error("Error:", error); // 요청 실패 시 에러 출력
+    throw error; // 에러를 다시 던져서 호출하는 곳에서 처리할 수 있도록 함
+  }
+};
+
+/**
+ * 신고하기 (댓글 신고, 게시글 신고, 유저 신고)
+ * @param title 신고 제목
+ * @param content 신고 내용
+ * @param reportType 신고 유형 (USER, POST, COMMENT)
+ * @param targetId 신고 대상 ID
+ * @param images 신고 이미지 목록
+ */
+export const reportUser = async ({
+  title,
+  content,
+  reportType,
+  targetId,
+  images, // 파일 목록
+}: IReportUser) => {
+  // FormData 생성
+  const formData = new FormData();
+  // JSON 데이터를 Blob으로 추가
+  const json = JSON.stringify({ title, content, reportType, targetId });
+  const blob = new Blob([json], { type: "application/json" });
+  formData.append("request", blob);
+
+  // 이미지 파일 존재하는 경우 이미 파일 목록 추가
+  if (images) {
+    images.forEach((img) => {
+      formData.append("images", img);
+    });
+  }
+  // HTTP 요청 전송
+  try {
+    const res = await axios.post(
+      `${import.meta.env.VITE_SERVER_URL}/api/v1/reports`,
+      formData,
+      {
+        withCredentials: true,
+      }
     );
     console.log("Response:", res.data); // 요청 성공 시 응답 데이터 출력
     return res.data; // 요청 성공 시 응답 데이터 반환

--- a/src/types/response/comment.d.ts
+++ b/src/types/response/comment.d.ts
@@ -7,6 +7,7 @@ export interface IComment {
   commentMemeberDto: {
     nickname: string;
     profileIamge: string;
+    userId: number;
   };
   content: string;
   isSeller: boolean;

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -11,6 +11,6 @@ export interface IReportUser {
   title: string;
   content: string;
   reportType: ReportType;
-  targetId: string;
+  targetId: number;
   images?: File[];
 }

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -4,3 +4,13 @@ export interface IUser {
   emdName?: string;
   emdId?: number;
 }
+
+export type ReportType = "USER" | "POST" | "COMMENT";
+
+export interface IReportUser {
+  title: string;
+  content: string;
+  reportType: ReportType;
+  targetId: string;
+  images?: File[];
+}


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #371 

## 💭 작업 내용

- 기존 문구 변경

**댓글**

차단하기 -> 유저 차단하기
신고하기 -> 유저 신고하기

**게시글**

차단하기 -> 유저 차단하기
신고하기 -> 유저 신고하기

- 신고하기 API 연동 완료

<!-- 작업한 내용을 간단히 설명해주세요 -->

## 🤔 참고 사항
- useDetailModal 훅 쪽에 confirm 모달 콜백함수로 TODO 작성된 부분이 있어 이 부분을 최대한 활용했습니다.
- 신고하기 요청 자체를 user 에 대한 신고로 보고 user api 쪽에 신고하는 API 추가했습니다.
- 신고할때 별도의 form 에 입력받지 않고 있기 때문에, 임의로 request 내용을 구성하도록 했습니다.
(댓글의 경우 댓글 내용포함, 게시글의 경우 게시글 제목, 게시글 내용 포함)
이 부분은 이후에 변경이 필요할 수도 있을 것 같습니다.
 
<!-- 참고 사항을 설명해주세요 -->

## 📸 스크린샷
![ReportPost](https://github.com/user-attachments/assets/b36a3395-bbfc-4e3b-99f1-187fa2c1fbac)
![ReportComment](https://github.com/user-attachments/assets/ae6095dd-c588-46e8-ad23-ae46e841ddbd)



<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
